### PR TITLE
Add -initWithFinishHandler: to OPBlockObserver

### DIFF
--- a/Pod/Classes/Observers/OPBlockObserver.h
+++ b/Pod/Classes/Observers/OPBlockObserver.h
@@ -38,4 +38,6 @@
                       produceHandler:(void (^)(OPOperation *operation, NSOperation *newOperation))produceHandler
                        finishHandler:(void (^)(OPOperation *operation, NSArray *errors))finishHandler;
 
+- (instancetype)initWithFinishHandler:(void(^)(OPOperation *operation, NSArray *errors))finishHandler;
+
 @end

--- a/Pod/Classes/Observers/OPBlockObserver.m
+++ b/Pod/Classes/Observers/OPBlockObserver.m
@@ -67,4 +67,8 @@
     return self;
 }
 
+- (instancetype)initWithFinishHandler:(void(^)(OPOperation *operation, NSArray *errors))finishHandler {
+    return [self initWithStartHandler:nil produceHandler:nil finishHandler:finishHandler];
+}
+
 @end


### PR DESCRIPTION
I found myself using observers to wait till certain operation finished to enqueue next one based on the result of preceding operation. That's said, standard initializer for block observer that takes three blocks is not convenient and overly verbose.

This is not the case in Swift since it allows you to provide the only block and it will correspond to the last parameter. That's said I think it would be a good deviation from Apple's code due to Objective-C limitations.

This is how it's done in Earthquakes app:

``` swift
let blockObserver = BlockObserver { _, errors in
    /*
        If the operation errored (ex: a condition failed) then the segue
        isn't going to happen. We shouldn't leave the row selected.
    */
    if !errors.isEmpty {
        dispatch_async(dispatch_get_main_queue()) {
            tableView.deselectRowAtIndexPath(indexPath, animated: true)
        }
    }
}
```
