### PR TITLE
Operation lifecycle tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,15 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
 # OS X
 .DS_Store
 
-# Xcode
+## Build generated
 build/
+DerivedData
+
+## Various settings
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -12,25 +19,40 @@ build/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata
+
+# Bundler
+.bundle
+.clang-format
+
+# AppCode
+.idea
+
+## Other
 *.xccheckout
 profile
 *.moved-aside
-DerivedData
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
 *.hmap
 *.ipa
 
 # vim
 *.swp
 
-# Bundler
-.bundle
-
-Carthage
+# CocoaPods
+#
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
-# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
-# Note: if you ignore the Pods directory, make sure to uncomment
-# `pod install` in .travis.yml
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
 # Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+Carthage.pkg

--- a/Pod/Classes/Conditions/OPLocationCondition.h
+++ b/Pod/Classes/Conditions/OPLocationCondition.h
@@ -35,6 +35,17 @@ typedef NS_ENUM(NSUInteger, OPLocationConditionUsage) {
  */
 @interface OPLocationCondition : NSObject <OPOperationCondition>
 
-- (instancetype)initWithUsage:(OPLocationConditionUsage)usage;
+/**
+ *  Designated initializer, otherwise calling `-init` will return an
+ *  `OPLocationCondition` with a default usage of
+ *  `OPLocationConditionWhenInUse`.
+ *
+ *  @param usage A value defining the required location usage permission in
+ *               order to satisfy the condition.
+ *
+ *  @return An `OPLocationCondition` object with the required location usage
+ *          permission defined.
+ */
+- (instancetype)initWithUsage:(OPLocationConditionUsage)usage NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/Pod/Classes/Conditions/OPNegatedCondition.h
+++ b/Pod/Classes/Conditions/OPNegatedCondition.h
@@ -44,9 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCondition:(id <OPOperationCondition>)condition NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Unused `-init` method. Do not use, will throw an exception.
- *
- *  @return Nothing returned, throws an exception if used.
+ *  Unused `-init` method.
+ *  @see - initWithCondition:
  */
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Pod/Classes/Conditions/OPNegatedCondition.m
+++ b/Pod/Classes/Conditions/OPNegatedCondition.m
@@ -30,13 +30,6 @@
  */
 @property (strong, nonatomic, readonly) id <OPOperationCondition> condition;
 
-/**
- *  Unused `-init` method. Do not used, will throw an exception.
- *
- *  @return Nothing returned, throws an exception if used.
- */
-- (instancetype)init NS_DESIGNATED_INITIALIZER; // Silences compiler crankiness
-
 @end
 
 
@@ -53,14 +46,6 @@
     _condition = condition;
 
     return self;
-}
-
-- (instancetype)init
-{
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:[NSString stringWithFormat:@"%@ not implemented, use -initWithCondition: instead", NSStringFromSelector(_cmd)]
-                                 userInfo:@{ @"file": @(__FILE__), @"line": @(__LINE__) }];
-    return nil;
 }
 
 

--- a/Pod/Classes/Conditions/OPOperationConditionMutuallyExclusive.h
+++ b/Pod/Classes/Conditions/OPOperationConditionMutuallyExclusive.h
@@ -37,7 +37,13 @@
  */
 + (OPOperationConditionMutuallyExclusive *)alertPresentationExclusivity;
 
-- (instancetype)initWithClass:(Class)cls;
+- (instancetype)initWithClass:(Class)cls NS_DESIGNATED_INITIALIZER;
+
+/**
+ *  Unused `-init` method.
+ *  @see -initWithClass:
+ */
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/Pod/Classes/Conditions/OPOperationConditionUserNotification.h
+++ b/Pod/Classes/Conditions/OPOperationConditionUserNotification.h
@@ -34,9 +34,17 @@ extern NSString * const kDesiredSettings;
 
 @interface OPOperationConditionUserNotification : NSObject <OPOperationCondition>
 
-/* designated initializer */
-- (instancetype) initWithSettings:(UIUserNotificationSettings *) settings application:(UIApplication *) application behavior:(OPOperationConditionUserNotificationBehavior) behavior;
-- (instancetype) initWithSettings:(UIUserNotificationSettings *) settings application:(UIApplication *) application;
+- (instancetype)initWithSettings:(UIUserNotificationSettings *)settings
+                     application:(UIApplication *)application
+                        behavior:(OPOperationConditionUserNotificationBehavior)behavior NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithSettings:(UIUserNotificationSettings *)settings application:(UIApplication *)application;
+
+/**
+ *  Unused `-init` method.
+ *  @see -initWithSettings:application:behavior
+ */
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/Pod/Classes/Conditions/OPReachabilityCondition.h
+++ b/Pod/Classes/Conditions/OPReachabilityCondition.h
@@ -32,4 +32,10 @@
 
 - (instancetype)initWithHost:(NSURL *)host NS_DESIGNATED_INITIALIZER;
 
+/**
+ *  Unused `-init` method.
+ *  @see -initWithHost:
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
 @end

--- a/Pod/Classes/Conditions/OPReachabilityCondition.m
+++ b/Pod/Classes/Conditions/OPReachabilityCondition.m
@@ -51,8 +51,6 @@ static NSString *const kOPOperationHostKey = @"OperationHost";
 
 @property (copy, nonatomic) NSURL *host;
 
-- (instancetype)init NS_DESIGNATED_INITIALIZER;
-
 @end
 
 
@@ -107,16 +105,6 @@ static NSString *const kOPOperationHostKey = @"OperationHost";
     }
     
     _host = [host copy];
-    
-    return self;
-}
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
     
     return self;
 }

--- a/Pod/Classes/Conditions/OPSilentCondition.h
+++ b/Pod/Classes/Conditions/OPSilentCondition.h
@@ -44,9 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCondition:(id <OPOperationCondition>)condition NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Unused `-init` method. Do not use, will throw an exception.
- *
- *  @return Nothing returned, throws an exception if used.
+ *  Unused `-init` method.
+ *  @see -initWithCondition:
  */
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Pod/Classes/Conditions/OPSilentCondition.m
+++ b/Pod/Classes/Conditions/OPSilentCondition.m
@@ -30,13 +30,6 @@
  */
 @property (strong, nonatomic, readonly) id <OPOperationCondition> condition;
 
-/**
- *  Unused `-init` method. Do not used, will throw an exception.
- *
- *  @return Nothing returned, throws an exception if used.
- */
-- (instancetype)init NS_DESIGNATED_INITIALIZER; // Silences compiler crankiness
-
 @end
 
 
@@ -53,14 +46,6 @@
     _condition = condition;
 
     return self;
-}
-
-- (instancetype)init
-{
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:[NSString stringWithFormat:@"%@ not implemented, use -initWithCondition: instead", NSStringFromSelector(_cmd)]
-                                 userInfo:@{ @"file": @(__FILE__), @"line": @(__LINE__) }];
-    return nil;
 }
 
 

--- a/Pod/Classes/Observers/OPBlockObserver.h
+++ b/Pod/Classes/Observers/OPBlockObserver.h
@@ -36,6 +36,6 @@
 
 - (instancetype)initWithStartHandler:(void (^)(OPOperation *operation))startHandler
                       produceHandler:(void (^)(OPOperation *operation, NSOperation *newOperation))produceHandler
-                       finishHandler:(void (^)(OPOperation *operation, NSArray *errors))finishHandler;
+                       finishHandler:(void (^)(OPOperation *operation, NSArray *errors))finishHandler NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/Pod/Classes/Observers/OPBlockObserver.m
+++ b/Pod/Classes/Observers/OPBlockObserver.m
@@ -22,6 +22,13 @@
 #import "OPBlockObserver.h"
 
 
+@interface OPBlockObserver ()
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+@end
+
+
 @implementation OPBlockObserver
 
 
@@ -53,7 +60,9 @@
 #pragma mark - Lifecycle
 #pragma mark -
 
-- (instancetype)initWithStartHandler:(void (^)(OPOperation *operation))startHandler produceHandler:(void (^)(OPOperation *operation, NSOperation *newOperation))produceHandler finishHandler:(void (^)(OPOperation *operation, NSArray *errors))finishHandler;
+- (instancetype)initWithStartHandler:(void (^)(OPOperation *operation))startHandler
+                      produceHandler:(void (^)(OPOperation *operation, NSOperation *newOperation))produceHandler
+                       finishHandler:(void (^)(OPOperation *operation, NSArray *errors))finishHandler;
 {
     self = [super init];
     if (!self) {
@@ -63,6 +72,16 @@
     _startHandler = [startHandler copy];
     _produceHander = [produceHandler copy];
     _finishHandler = [finishHandler copy];
+
+    return self;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
 
     return self;
 }

--- a/Pod/Classes/Observers/OPNetworkObserver.h
+++ b/Pod/Classes/Observers/OPNetworkObserver.h
@@ -28,6 +28,4 @@
  */
 @interface OPNetworkObserver : NSObject <OPOperationObserver>
 
-
-
 @end

--- a/Pod/Classes/Observers/OPNetworkObserver.m
+++ b/Pod/Classes/Observers/OPNetworkObserver.m
@@ -29,11 +29,11 @@
 
 @property (assign, nonatomic, getter=isCancelled) BOOL cancelled;
 
-@property (copy, nonatomic) dispatch_block_t handler;
+@property (copy, nonatomic, readonly) dispatch_block_t handler;
 
 - (instancetype)initWithInterval:(NSTimeInterval)interval handler:(dispatch_block_t)handler NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)init NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
 
 - (void)cancel;
 
@@ -166,15 +166,24 @@
 
 @implementation OPTimer
 
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
+#pragma mark - Public
+#pragma mark -
 
-    return self;
+- (void)cancel
+{
+    [self setCancelled:YES];
 }
+
+- (void)fire
+{
+    if (![self isCancelled]) {
+        self.handler();
+    }
+}
+
+
+#pragma mark - Lifecycle
+#pragma mark -
 
 - (instancetype)initWithInterval:(NSTimeInterval)interval
                          handler:(dispatch_block_t)handler
@@ -195,18 +204,6 @@
     });
 
     return self;
-}
-
-- (void)cancel
-{
-    [self setCancelled:YES];
-}
-
-- (void)fire
-{
-    if (![self isCancelled]) {
-        self.handler();
-    }
 }
 
 @end

--- a/Pod/Classes/Observers/OPTimeoutObserver.h
+++ b/Pod/Classes/Observers/OPTimeoutObserver.h
@@ -32,4 +32,10 @@
 
 - (instancetype)initWithTimeout:(NSTimeInterval)timeout NS_DESIGNATED_INITIALIZER;
 
+/**
+ *  Unused `-init` method.
+ *  @see -initWithTimeout:
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
 @end

--- a/Pod/Classes/Observers/OPTimeoutObserver.m
+++ b/Pod/Classes/Observers/OPTimeoutObserver.m
@@ -31,8 +31,6 @@ static NSString *const kOPTimeoutObserverErrorKey = @"OPTimeoutObserverError";
 
 @property (assign, nonatomic) NSTimeInterval timeout;
 
-- (instancetype)init NS_DESIGNATED_INITIALIZER;
-
 @end
 
 
@@ -82,16 +80,6 @@ static NSString *const kOPTimeoutObserverErrorKey = @"OPTimeoutObserverError";
 
     _timeout = timeout;
 
-    return self;
-}
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    
     return self;
 }
 

--- a/Pod/Classes/Operation Queue/OPOperationQueue.m
+++ b/Pod/Classes/Operation Queue/OPOperationQueue.m
@@ -37,9 +37,7 @@
         __weak __typeof__(self) weakSelf = self;
         id <OPOperationObserver>observer = [[OPBlockObserver alloc] initWithStartHandler:nil
                                                                           produceHandler:^(__unused OPOperation *anOperation, NSOperation *newOperation) {
-                                                                              if (weakSelf) {
-                                                                                  [weakSelf addOperation:newOperation];
-                                                                              }
+                                                                              [weakSelf addOperation:newOperation];
                                                                           }
                                                                            finishHandler:^(OPOperation *anOperation, NSArray *errors) {
                                                                                __typeof__(self) strongSelf = weakSelf;

--- a/Pod/Classes/Operation Queue/OPOperationQueue.m
+++ b/Pod/Classes/Operation Queue/OPOperationQueue.m
@@ -34,13 +34,17 @@
         OPOperation *opOperation = (OPOperation *)operation;
 
         // Set up a `OPBlockObserver` to invoke the `OPOperationQueueDelegate` method.
+        __weak __typeof__(self) weakSelf = self;
         id <OPOperationObserver>observer = [[OPBlockObserver alloc] initWithStartHandler:nil
                                                                           produceHandler:^(__unused OPOperation *anOperation, NSOperation *newOperation) {
-                                                                              [self addOperation:newOperation];
+                                                                              if (weakSelf) {
+                                                                                  [weakSelf addOperation:newOperation];
+                                                                              }
                                                                           }
                                                                            finishHandler:^(OPOperation *anOperation, NSArray *errors) {
-                                                                               if ([self delegate] && [self.delegate respondsToSelector:@selector(operationQueue:operationDidFinish:withErrors:)]) {
-                                                                                   [self.delegate operationQueue:self operationDidFinish:anOperation withErrors:errors];
+                                                                               __typeof__(self) strongSelf = weakSelf;
+                                                                               if ([strongSelf delegate] && [strongSelf.delegate respondsToSelector:@selector(operationQueue:operationDidFinish:withErrors:)]) {
+                                                                                   [strongSelf.delegate operationQueue:strongSelf operationDidFinish:anOperation withErrors:errors];
                                                                                }
                                                                            }];
 
@@ -108,7 +112,10 @@
         }];
     }
 
-    [self.delegate operationQueue:self willAddOperation:operation];
+    if ([self delegate] && [self.delegate respondsToSelector:@selector(operationQueue:willAddOperation:)]) {
+        [self.delegate operationQueue:self willAddOperation:operation];
+    }
+
     [super addOperation:operation];
 }
 

--- a/Pod/Classes/Operation Queue/OPOperationQueue.m
+++ b/Pod/Classes/Operation Queue/OPOperationQueue.m
@@ -35,12 +35,12 @@
 
         // Set up a `OPBlockObserver` to invoke the `OPOperationQueueDelegate` method.
         id <OPOperationObserver>observer = [[OPBlockObserver alloc] initWithStartHandler:nil
-                                                                          produceHandler:^(__unused OPOperation *operation, NSOperation *newOperation) {
+                                                                          produceHandler:^(__unused OPOperation *anOperation, NSOperation *newOperation) {
                                                                               [self addOperation:newOperation];
                                                                           }
-                                                                           finishHandler:^(OPOperation *operation, NSArray *errors) {
+                                                                           finishHandler:^(OPOperation *anOperation, NSArray *errors) {
                                                                                if ([self delegate] && [self.delegate respondsToSelector:@selector(operationQueue:operationDidFinish:withErrors:)]) {
-                                                                                   [self.delegate operationQueue:self operationDidFinish:operation withErrors:errors];
+                                                                                   [self.delegate operationQueue:self operationDidFinish:anOperation withErrors:errors];
                                                                                }
                                                                            }];
 
@@ -76,8 +76,8 @@
 
             OPBlockObserver *blockObserver = [[OPBlockObserver alloc] initWithStartHandler:nil
                                                                             produceHandler:nil
-                                                                             finishHandler:^(__unused OPOperation *operation, __unused NSArray *errors) {
-                                                                                 [exclusivityController removeOperation:opOperation categories:concurrencyCategories];
+                                                                             finishHandler:^(OPOperation *anOperation, __unused NSArray *errors) {
+                                                                                 [exclusivityController removeOperation:anOperation categories:concurrencyCategories];
                                                                              }];
             [opOperation addObserver:blockObserver];
         }

--- a/Pod/Classes/Operations/Misc/OPBlockOperation.h
+++ b/Pod/Classes/Operations/Misc/OPBlockOperation.h
@@ -62,4 +62,11 @@ typedef void (^OPOperationBlock)(void (^completion)(void));
  */
 - (instancetype)initWithMainQueueBlock:(void (^)(void))mainQueueBlock;
 
+/**
+ *  Unused `-init` method.
+ *  @see -initWithBlock:
+ *  @see -initWithMainQueueBlock:
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
 @end

--- a/Pod/Classes/Operations/Misc/OPBlockOperation.m
+++ b/Pod/Classes/Operations/Misc/OPBlockOperation.m
@@ -26,8 +26,6 @@
 
 @property (copy, nonatomic) OPOperationBlock block;
 
-- (instancetype)init NS_DESIGNATED_INITIALIZER;
-
 @end
 
 @implementation OPBlockOperation
@@ -73,16 +71,6 @@
     };
     
     return [self initWithBlock:block];
-}
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    
-    return self;
 }
 
 @end

--- a/Pod/Classes/Operations/Misc/OPDelayOperation.h
+++ b/Pod/Classes/Operations/Misc/OPDelayOperation.h
@@ -37,8 +37,15 @@
  */
 @interface OPDelayOperation : OPOperation
 
+- (instancetype)initWithTimeInterval:(NSTimeInterval)interval NS_DESIGNATED_INITIALIZER;
+
 - (instancetype)initWithDate:(NSDate *)date;
 
-- (instancetype)initWithTimeInterval:(NSTimeInterval)interval;
+/**
+ *  Unused `-init` method.
+ *  @see -initWithTimeInterval:
+ *  @see -initWithDate:
+ */
+- (instancetype)init NS_UNAVAILABLE;
 
 @end

--- a/Pod/Classes/Operations/Misc/OPDelayOperation.m
+++ b/Pod/Classes/Operations/Misc/OPDelayOperation.m
@@ -63,11 +63,6 @@
 #pragma mark - Lifecycle
 #pragma mark -
 
-- (instancetype)initWithDate:(NSDate *)date
-{
-    return [self initWithTimeInterval:[date timeIntervalSinceNow]];
-}
-
 - (instancetype)initWithTimeInterval:(NSTimeInterval)interval
 {
     self = [super init];
@@ -78,6 +73,11 @@
     _delay = interval;
 
     return self;
+}
+
+- (instancetype)initWithDate:(NSDate *)date
+{
+    return [self initWithTimeInterval:[date timeIntervalSinceNow]];
 }
 
 @end

--- a/Pod/Classes/Operations/Misc/OPGroupOperation.h
+++ b/Pod/Classes/Operations/Misc/OPGroupOperation.h
@@ -39,7 +39,16 @@
  */
 @interface OPGroupOperation : OPOperation
 
-- (instancetype)initWithOperations:(NSArray *)operations;
+/**
+ *  Initializes an `OPGroupOperation` object and adds the provided operations to
+ *  its internal queue
+ *
+ *  @param operations An `NSArray` of operations to be group together into a
+ *                    single executable operation.
+ *
+ *  @return An `OPGroupOperation` object
+ */
+- (instancetype)initWithOperations:(NSArray *)operations NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Adds an operation to the group after instantiation

--- a/Pod/Classes/Operations/Misc/OPGroupOperation.m
+++ b/Pod/Classes/Operations/Misc/OPGroupOperation.m
@@ -25,6 +25,13 @@
 
 @interface OPGroupOperation() <OPOperationQueueDelegate>
 
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+/**
+ *  Common initialized elements used in both `-init` & `-initWithOperations:`
+ */
+- (void)commonInit;
+
 @property (strong, nonatomic) OPOperationQueue *internalQueue;
 @property (strong, nonatomic) NSBlockOperation *finishingOperation;
 
@@ -106,32 +113,43 @@
     if (!self) {
         return nil;
     }
-
-    OPOperationQueue *queue = [[OPOperationQueue alloc] init];
-    [queue setSuspended:YES];
-    [queue setDelegate:self];
-
-    _internalQueue = queue;
     
-    _finishingOperation = [NSBlockOperation blockOperationWithBlock:^{}];
-    
-    _aggregatedErrors = [[NSMutableArray alloc] init];
+    [self commonInit];
     
     return self;
 }
 
 - (instancetype)initWithOperations:(NSArray *)operations
 {
-    self = [self init];
+    self = [super init];
     if (!self) {
         return nil;
     }
+    
+    [self commonInit];
     
     for (NSOperation *operation in operations) {
         [_internalQueue addOperation:operation];
     }
     
     return self;
+}
+
+
+#pragma mark - Private
+#pragma mark -
+
+- (void)commonInit
+{
+    OPOperationQueue *queue = [[OPOperationQueue alloc] init];
+    [queue setSuspended:YES];
+    [queue setDelegate:self];
+    
+    _internalQueue = queue;
+    
+    _finishingOperation = [NSBlockOperation blockOperationWithBlock:^{}];
+    
+    _aggregatedErrors = [[NSMutableArray alloc] init];
 }
 
 @end

--- a/Pod/Classes/Operations/Misc/OPLocationOperation.h
+++ b/Pod/Classes/Operations/Misc/OPLocationOperation.h
@@ -38,4 +38,10 @@
 - (instancetype)initWithAccuracy:(CLLocationAccuracy)accuracy
                  locationHandler:(void (^)(CLLocation *location))locationHandler NS_DESIGNATED_INITIALIZER;
 
+/**
+ *  Unused `-init` method.
+ *  @see -initWithAccuracy:locationHandler:
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
 @end

--- a/Pod/Classes/Operations/Networking/OPURLSessionTaskOperation.h
+++ b/Pod/Classes/Operations/Networking/OPURLSessionTaskOperation.h
@@ -37,4 +37,10 @@
 
 - (instancetype)initWithTask:(NSURLSessionTask *)task NS_DESIGNATED_INITIALIZER;
 
+/**
+ *  Unused `-init` method.
+ *  @see -initWithTask:
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
 @end

--- a/Pod/Classes/Operations/Networking/OPURLSessionTaskOperation.m
+++ b/Pod/Classes/Operations/Networking/OPURLSessionTaskOperation.m
@@ -27,8 +27,6 @@ static void * OPURLSessionOperationKVOContext = &OPURLSessionOperationKVOContext
 
 @interface OPURLSessionTaskOperation ()
 
-- (instancetype)init NS_DESIGNATED_INITIALIZER;
-
 @property (strong, nonatomic) NSURLSessionTask *task;
 
 @end
@@ -99,16 +97,6 @@ static void * OPURLSessionOperationKVOContext = &OPURLSessionOperationKVOContext
 
     _task = task;
 
-    return self;
-}
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    
     return self;
 }
 

--- a/Pod/Classes/Operations/UI/OPAlertOperation.h
+++ b/Pod/Classes/Operations/UI/OPAlertOperation.h
@@ -30,6 +30,12 @@
 
 - (instancetype)initWithPresentationContext:(UIViewController *)viewController NS_DESIGNATED_INITIALIZER;
 
+/**
+ *  Unused `-init` method.
+ *  @see -initWithPresentationContext:
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
 @property (copy, nonatomic) NSString *title;
 
 @property (copy, nonatomic) NSString *message;

--- a/Pod/Classes/Operations/UI/OPAlertOperation.m
+++ b/Pod/Classes/Operations/UI/OPAlertOperation.m
@@ -27,8 +27,6 @@
 
 @interface OPAlertOperation ()
 
-- (instancetype)init NS_DESIGNATED_INITIALIZER;
-
 @property (strong, nonatomic) UIAlertController *alertController;
 
 @property (strong, nonatomic) UIViewController *presentationContext;
@@ -138,16 +136,6 @@
      */
     [self addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[UIViewController class]]];
 
-    return self;
-}
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    
     return self;
 }
 


### PR DESCRIPTION
# Summary
- Changes how we are handling `-init` for objects that are declaring `NS_DESIGNATED_INITIALIZER` on a method aside from `-init` (and don't subsequently use `-init` in any way, marked as `NS_UNAVAILABLE`), across the entire Operative framework.
- Some general clean up around compiler warnings and `-init`
- Documents `OPLocationCondition`s designated initializer
- Documents `OPGroupOperation`s designated initializer
- Documents `NS_UNAVAILABLE` `-init` methods with appropriate `@see` reference to designated initializers across the entire Operative framework.
- Updates `.gitignore` with typical Carthage stuff as well as AppCode stuff. Tidying.
## References
- Similar changes to `OPOperationQueue` as #16, however some additional "guarding" (carry over of Swift optionals) and potential for referencing a `nil` delegate. Ultimately better alignment with Advance NSOperations implementation.
