### PR TITLE
NSURLSessionTask errors option

### DIFF
--- a/Pod/Classes/Operations/Networking/OPURLSessionTaskOperation.h
+++ b/Pod/Classes/Operations/Networking/OPURLSessionTaskOperation.h
@@ -28,13 +28,32 @@
  *
  *  Note that this operation does not participate in any of the delegate callbacks
  *  of an `NSURLSession`, but instead uses Key-Value-Observing to know when the
- *  task has been completed. It also does not get notified about any errors that
- *  occurred during execution of the task.
+ *  task has been completed. By default the operation gets notified of errors that occur during
+ *  execution of the task. Upon completion, if the task has produced an error,
+ *  `-finishWithError:` will receive this error and the operation will accrue the error
+ *  from the task as an internal error.
+ *
+ *  As an option, one can set the value of `shouldSuppressErrors` to YES
+ *  and the operation will not get notified about any errors that occurred during
+ *  execution of the task.
+ *
+ *  @see shouldSuppressErrors
  *
  *  - returns: An instance of an `OPURLSessionTaskOperation`
  */
 @interface OPURLSessionTaskOperation : OPOperation
 
 - (instancetype)initWithTask:(NSURLSessionTask *)task NS_DESIGNATED_INITIALIZER;
+
+/**
+ *  Evaluated upon completion of the provided `NSURLSessionTask`, this value
+ *  dictates how errors occurring during the execution of the task are handled.
+ *
+ *  If set to YES, completion of the task will not pass along any errors that
+ *  may have occurred during execution to the operation via -finishedWithError:.
+ *
+ *  Defaults to NO
+ */
+@property (assign, nonatomic) BOOL shouldSuppressErrors;
 
 @end

--- a/Pod/Classes/Operations/Networking/OPURLSessionTaskOperation.m
+++ b/Pod/Classes/Operations/Networking/OPURLSessionTaskOperation.m
@@ -71,11 +71,11 @@ static void * OPURLSessionOperationKVOContext = &OPURLSessionOperationKVOContext
                     [object removeObserver:self forKeyPath:NSStringFromSelector(@selector(state))];
                 }
                 @catch (NSException *__unused exception) {}
-                
-                if (_task.error) {
-                    [self finishWithError:_task.error];
-                } else {
+
+                if ([self shouldSuppressErrors]) {
                     [self finish];
+                } else {
+                    [self finishWithError:[self.task error]];
                 }
             }
         }
@@ -98,6 +98,7 @@ static void * OPURLSessionOperationKVOContext = &OPURLSessionOperationKVOContext
     NSAssert([task state] == NSURLSessionTaskStateSuspended, @"Tasks must be suspended.");
 
     _task = task;
+    _shouldSuppressErrors = NO;
 
     return self;
 }


### PR DESCRIPTION
# Summary
- Implements `shouldSuppressErrors`: a `BOOL` flag that can be set on `OPURLSessionTaskOperation` allowing the ability to control how errors are handled upon task completion. Defaults to `NO`
# Reference
- https://github.com/Kabal/Operative/commit/5abe4ad7d4bd284f47c43920f6411c042e4fadaf
- #10
