### PR TITLE
Alert preferred style

### DIFF
--- a/Pod/Classes/Operations/UI/OPAlertOperation.h
+++ b/Pod/Classes/Operations/UI/OPAlertOperation.h
@@ -28,10 +28,23 @@
 
 @interface OPAlertOperation : OPOperation
 
-- (instancetype)initWithPresentationContext:(UIViewController *)viewController NS_DESIGNATED_INITIALIZER;
+/**
+ *  Initializes an instance of OPAlertOperation with the contained
+ *  UIAlertController's UIAlertControllerStyle defaulted to
+ *  UIAlertControllerStyleActionSheet
+ *
+ *  @see -initWithPresentationContext:preferredStyle
+ *
+ *  @param presentationContext UIViewController from which the UIAlertController
+ *                             will be present. If nil then this will default to
+ *                             the rootViewController of the sharedApplication.
+ *
+ *  @return An initialized OPAlertOperation
+ */
+- (instancetype)initWithPresentationContext:(UIViewController *)presentationContext;
 
-- (instancetype)initWithPresentationContext:(UIViewController *)viewController
-                             preferredStyle:(UIAlertControllerStyle)preferredStyle;
+- (instancetype)initWithPresentationContext:(UIViewController *)presentationContext
+                             preferredStyle:(UIAlertControllerStyle)preferredStyle NS_DESIGNATED_INITIALIZER;
 
 @property (copy, nonatomic) NSString *title;
 

--- a/Pod/Classes/Operations/UI/OPAlertOperation.h
+++ b/Pod/Classes/Operations/UI/OPAlertOperation.h
@@ -30,6 +30,9 @@
 
 - (instancetype)initWithPresentationContext:(UIViewController *)viewController NS_DESIGNATED_INITIALIZER;
 
+- (instancetype)initWithPresentationContext:(UIViewController *)viewController
+                             preferredStyle:(UIAlertControllerStyle)preferredStyle;
+
 @property (copy, nonatomic) NSString *title;
 
 @property (copy, nonatomic) NSString *message;

--- a/Pod/Classes/Operations/UI/OPAlertOperation.m
+++ b/Pod/Classes/Operations/UI/OPAlertOperation.m
@@ -125,18 +125,25 @@
         return nil;
     }
 
-    _presentationContext = viewController ?: [[[UIApplication sharedApplication] keyWindow] rootViewController];
-
     _alertController = [[UIAlertController alloc] init];
 
-    [self addCondition:[OPOperationConditionMutuallyExclusive alertPresentationExclusivity]];
-    
-    /**
-     *  This operation modifies the view controller hierarchy.
-     *  Doing this while other such operations are executing can lead to
-     *  inconsistencies in UIKit. So, let's make them mutally exclusive.
-     */
-    [self addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[UIViewController class]]];
+    [self commonInitWithPresentationContext:viewController];
+
+    return self;
+}
+
+- (instancetype)initWithPresentationContext:(UIViewController *)viewController
+                             preferredStyle:(UIAlertControllerStyle)preferredStyle
+{
+    self = [super init];
+
+    if (!self) {
+        return nil;
+    }
+
+    _alertController = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:preferredStyle];
+
+    [self commonInitWithPresentationContext:viewController];
 
     return self;
 }
@@ -149,6 +156,20 @@
     }
     
     return self;
+}
+
+- (void)commonInitWithPresentationContext:(UIViewController *)viewController
+{
+    _presentationContext = viewController ?: [[[UIApplication sharedApplication] keyWindow] rootViewController];
+
+    [self addCondition:[OPOperationConditionMutuallyExclusive alertPresentationExclusivity]];
+
+    /**
+     *  This operation modifies the view controller hierarchy.
+     *  Doing this while other such operations are executing can lead to
+     *  inconsistencies in UIKit. So, let's make them mutally exclusive.
+     */
+    [self addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[UIViewController class]]];
 }
 
 @end

--- a/Pod/Classes/Operations/UI/OPAlertOperation.m
+++ b/Pod/Classes/Operations/UI/OPAlertOperation.m
@@ -117,22 +117,18 @@
 #pragma mark - Lifecycle
 #pragma mark -
 
-- (instancetype)initWithPresentationContext:(UIViewController *)viewController
+- (instancetype)initWithPresentationContext:(UIViewController *)presentationContext
 {
-    self = [super init];
-
+    self = [self initWithPresentationContext:presentationContext
+                              preferredStyle:UIAlertControllerStyleActionSheet];
     if (!self) {
         return nil;
     }
 
-    _alertController = [[UIAlertController alloc] init];
-
-    [self commonInitWithPresentationContext:viewController];
-
     return self;
 }
 
-- (instancetype)initWithPresentationContext:(UIViewController *)viewController
+- (instancetype)initWithPresentationContext:(UIViewController *)presentationContext
                              preferredStyle:(UIAlertControllerStyle)preferredStyle
 {
     self = [super init];
@@ -142,8 +138,17 @@
     }
 
     _alertController = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:preferredStyle];
-
-    [self commonInitWithPresentationContext:viewController];
+    
+    _presentationContext = presentationContext ?: [[[UIApplication sharedApplication] keyWindow] rootViewController];
+    
+    [self addCondition:[OPOperationConditionMutuallyExclusive alertPresentationExclusivity]];
+    
+    /**
+     *  This operation modifies the view controller hierarchy.
+     *  Doing this while other such operations are executing can lead to
+     *  inconsistencies in UIKit. So, let's make them mutally exclusive.
+     */
+    [self addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[UIViewController class]]];
 
     return self;
 }
@@ -156,20 +161,6 @@
     }
     
     return self;
-}
-
-- (void)commonInitWithPresentationContext:(UIViewController *)viewController
-{
-    _presentationContext = viewController ?: [[[UIApplication sharedApplication] keyWindow] rootViewController];
-
-    [self addCondition:[OPOperationConditionMutuallyExclusive alertPresentationExclusivity]];
-
-    /**
-     *  This operation modifies the view controller hierarchy.
-     *  Doing this while other such operations are executing can lead to
-     *  inconsistencies in UIKit. So, let's make them mutally exclusive.
-     */
-    [self addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[UIViewController class]]];
 }
 
 @end


### PR DESCRIPTION
# Summary
- Simple addition to `OPAlertOperation` allowing the `UIAlertControllerStyle` to be defined upon instantiation.
