### PR TITLE
Block observers tests

### DIFF
--- a/Example/Operative.xcodeproj/project.pbxproj
+++ b/Example/Operative.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		36BA00E658229C477F35A1DB /* libPods-Operative_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 860340B98354D8E2F499AE43 /* libPods-Operative_Example.a */; };
+		58898F091BEE0975001AC718 /* BlockObserversTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58898F081BEE0975001AC718 /* BlockObserversTests.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -41,6 +42,7 @@
 		0A8F82578DDF2C89BEDA7C41 /* Operative.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Operative.podspec; path = ../Operative.podspec; sourceTree = "<group>"; };
 		2DE792D5C4560BBB37DB3592 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		3050B054C14E8A45839ECF46 /* Pods-Operative_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Tests/Pods-Operative_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		58898F081BEE0975001AC718 /* BlockObserversTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlockObserversTests.m; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* Operative_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Operative_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -164,6 +166,7 @@
 			children = (
 				6003F5BB195388D20070C39A /* Tests.m */,
 				E220B58E1B36BE8E00D706E1 /* CategoriesTests.m */,
+				58898F081BEE0975001AC718 /* BlockObserversTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -403,6 +406,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6003F5BC195388D20070C39A /* Tests.m in Sources */,
+				58898F091BEE0975001AC718 /* BlockObserversTests.m in Sources */,
 				E220B5901B36BE9100D706E1 /* CategoriesTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tests/BlockObserversTests.m
+++ b/Example/Tests/BlockObserversTests.m
@@ -1,10 +1,23 @@
+// BlockObserversTests.m
+// Copyright (c) 2015 Tom Wilson <tom@toms-stuff.net>
 //
-//  BlockObserversTests.m
-//  Operative
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by pronebird on 11/7/15.
-//  Copyright © 2015 Tom Wilson. All rights reserved.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
 

--- a/Example/Tests/BlockObserversTests.m
+++ b/Example/Tests/BlockObserversTests.m
@@ -1,0 +1,86 @@
+//
+//  BlockObserversTests.m
+//  Operative
+//
+//  Created by pronebird on 11/7/15.
+//  Copyright © 2015 Tom Wilson. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <Operative/Operative.h>
+
+@interface BlockObserversTests : XCTestCase
+
+@end
+
+@implementation BlockObserversTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testStartHandler {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Block observer should call start handler"];
+    
+    OPOperationQueue *operationQueue = [[OPOperationQueue alloc] init];
+    OPOperation *operation = [[OPOperation alloc] init];
+    
+    [operation addObserver:[[OPBlockObserver alloc] initWithStartHandler:^(OPOperation *operation) {
+        [expectation fulfill];
+    } produceHandler:^(OPOperation *operation, NSOperation *newOperation) {
+        
+    } finishHandler:^(OPOperation *operation, NSArray *errors) {
+        
+    }]];
+    
+    [operationQueue addOperation:operation];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testFinishHandler {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Block observer should call finish handler"];
+    
+    OPOperationQueue *operationQueue = [[OPOperationQueue alloc] init];
+    OPOperation *operation = [[OPOperation alloc] init];
+    
+    [operation addObserver:[[OPBlockObserver alloc] initWithStartHandler:^(OPOperation *operation) {
+        
+    } produceHandler:^(OPOperation *operation, NSOperation *newOperation) {
+        
+    } finishHandler:^(OPOperation *operation, NSArray *errors) {
+        [expectation fulfill];
+    }]];
+    
+    [operationQueue addOperation:operation];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testProduceHandler {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Block observer should call produce handler"];
+    
+    OPOperationQueue *operationQueue = [[OPOperationQueue alloc] init];
+    OPOperation *operation = [[OPOperation alloc] init];
+    
+    [operation addObserver:[[OPBlockObserver alloc] initWithStartHandler:^(OPOperation *operation) {
+        
+    } produceHandler:^(OPOperation *operation, NSOperation *newOperation) {
+        [expectation fulfill];
+    } finishHandler:^(OPOperation *operation, NSArray *errors) {
+        [operation produceOperation:[[OPOperation alloc] init]];
+    }]];
+    
+    [operationQueue addOperation:operation];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+@end


### PR DESCRIPTION
Three tests to test that start/produce/finish handlers are called for block observers.
