### PR TITLE
Block observer init

### DIFF
--- a/Pod/Classes/Observers/OPBlockObserver.h
+++ b/Pod/Classes/Observers/OPBlockObserver.h
@@ -40,6 +40,4 @@
 
 - (instancetype)initWithFinishHandler:(void(^)(OPOperation *operation, NSArray *errors))finishHandler;
 
-- (instancetype)init NS_UNAVAILABLE;
-
 @end

--- a/Pod/Classes/Observers/OPBlockObserver.m
+++ b/Pod/Classes/Observers/OPBlockObserver.m
@@ -21,6 +21,14 @@
 
 #import "OPBlockObserver.h"
 
+
+@interface OPBlockObserver ()
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+@end
+
+
 @implementation OPBlockObserver
 
 
@@ -68,8 +76,19 @@
     return self;
 }
 
-- (instancetype)initWithFinishHandler:(void(^)(OPOperation *operation, NSArray *errors))finishHandler {
+- (instancetype)initWithFinishHandler:(void (^)(OPOperation *operation, NSArray *errors))finishHandler
+{
     return [self initWithStartHandler:nil produceHandler:nil finishHandler:finishHandler];
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    return self;
 }
 
 @end


### PR DESCRIPTION
# Summary
- Bringing back the ability to just call `-init` on `OPBlockObserver`. Init should _not_ be marked as `NS_UNAVAILABLE` because the properties are publicly read write and one should be able to make a block observer with any combination of block events if they would like.
# Reference
- 1bd8da8
