### PR TITLE
Conditions tests: Mutually exclusive

### DIFF
--- a/Example/Operative.xcodeproj/project.pbxproj
+++ b/Example/Operative.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		36BA00E658229C477F35A1DB /* libPods-Operative_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 860340B98354D8E2F499AE43 /* libPods-Operative_Example.a */; };
+		589BADD41BECC6C60051139A /* ConditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 589BADD31BECC6C60051139A /* ConditionsTests.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -41,6 +42,7 @@
 		0A8F82578DDF2C89BEDA7C41 /* Operative.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Operative.podspec; path = ../Operative.podspec; sourceTree = "<group>"; };
 		2DE792D5C4560BBB37DB3592 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		3050B054C14E8A45839ECF46 /* Pods-Operative_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Tests/Pods-Operative_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		589BADD31BECC6C60051139A /* ConditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConditionsTests.m; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* Operative_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Operative_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -164,6 +166,7 @@
 			children = (
 				6003F5BB195388D20070C39A /* Tests.m */,
 				E220B58E1B36BE8E00D706E1 /* CategoriesTests.m */,
+				589BADD31BECC6C60051139A /* ConditionsTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -403,6 +406,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6003F5BC195388D20070C39A /* Tests.m in Sources */,
+				589BADD41BECC6C60051139A /* ConditionsTests.m in Sources */,
 				E220B5901B36BE9100D706E1 /* CategoriesTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tests/ConditionsTests.m
+++ b/Example/Tests/ConditionsTests.m
@@ -1,0 +1,94 @@
+// ConditionsTests.m
+// Copyright (c) 2015 Tom Wilson <tom@toms-stuff.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+
+#import <Operative/Operative.h>
+#import <Operative/OPOperationConditionMutuallyExclusive.h>
+
+@interface ConditionsTests : XCTestCase
+
+@end
+
+@implementation ConditionsTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testMutuallyExclusiveOperations {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Should chain all mutually exclusive operations."];
+    
+    OPOperationQueue *operationQueue = [[OPOperationQueue alloc] init];
+    NSMutableArray *operations = [[NSMutableArray alloc] init];
+    
+    __weak OPOperationQueue *weakQueue = operationQueue;
+    
+    // start operation will be the first to execute and it should verify that all mutually exclusive ops
+    // are properly connected in a chain using dependencies.
+    OPBlockOperation *startOperation = [[OPBlockOperation alloc] initWithMainQueueBlock:^{
+        NSMutableArray *allOperations = [[weakQueue operations] mutableCopy];
+        NSMutableArray *reversedOperations = [[[allOperations reverseObjectEnumerator] allObjects] mutableCopy];
+        
+        // check if operations were linked in a chain
+        while(reversedOperations.count > 0) {
+            OPOperation *followingOp = reversedOperations.firstObject;
+            OPOperation *precedingOp = [reversedOperations objectAtIndex:1];
+            
+            // start operation is a block operation.
+            if([precedingOp isKindOfClass:[OPBlockOperation class]]) {
+                [expectation fulfill];
+                return;
+            }
+            
+            XCTAssertEqual(followingOp.dependencies.count, 1, @"Mutually exclusive ops are chained. Each op should have one dependency.");
+            XCTAssertEqual(followingOp.dependencies.firstObject, precedingOp, @"Following operation should dependent on preceding operation.");
+            
+            [reversedOperations removeObject:followingOp];
+        }
+    }];
+    
+    for(NSInteger i = 0; i < 4; i++) {
+        OPOperation *operation = [[OPOperation alloc] init];
+        
+        [operation addCondition:[[OPOperationConditionMutuallyExclusive alloc] initWithClass:[operation class]]];
+        
+        [operations addObject:operation];
+    }
+    
+    // make first exclusive operation to run after startOperation.
+    [operations.firstObject addDependency:startOperation];
+    
+    // insert start operation in the beginning to make it easier to verify mutual exclusivity
+    [operations insertObject:startOperation atIndex:0];
+    
+    [operationQueue addOperations:operations waitUntilFinished:NO];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+@end

--- a/Example/Tests/ConditionsTests.m
+++ b/Example/Tests/ConditionsTests.m
@@ -66,7 +66,7 @@
             }
             
             XCTAssertEqual(followingOp.dependencies.count, 1, @"Mutually exclusive ops are chained. Each op should have one dependency.");
-            XCTAssertEqual(followingOp.dependencies.firstObject, precedingOp, @"Following operation should dependent on preceding operation.");
+            XCTAssertEqual(followingOp.dependencies.firstObject, precedingOp, @"Following operation should depend on preceding operation.");
             
             [reversedOperations removeObject:followingOp];
         }


### PR DESCRIPTION
This test registers a mutually exclusive operation and expects all of its instances to be chained with dependencies. Then it goes backwards through all enqueued ops and checks if ops are linked to each other until it hits the start operation.

I'd appreciate if you could have a fresh look at this test and maybe make it more reliable or less verbose.
