### PR TITLE
Add parameter name to fix Xcode autocompletion issues

### DIFF
--- a/Pod/Classes/Operations/UI/OPAlertOperation.h
+++ b/Pod/Classes/Operations/UI/OPAlertOperation.h
@@ -58,7 +58,7 @@
 
 - (void)addAction:(NSString *)title
             style:(UIAlertActionStyle)style
-          handler:(void (^)(OPAlertOperation *))handler;
+          handler:(void (^)(OPAlertOperation *alertOperation))handler;
 
 @end
 

--- a/Pod/Classes/Operations/UI/OPAlertOperation.m
+++ b/Pod/Classes/Operations/UI/OPAlertOperation.m
@@ -42,7 +42,7 @@
 
 - (void)addAction:(NSString *)title
             style:(UIAlertActionStyle)style
-          handler:(void (^)(OPAlertOperation *))handler;
+          handler:(void (^)(OPAlertOperation *alertOperation))handler;
 {
     __weak __typeof__(self) weakSelf = self;
     UIAlertAction *action = [UIAlertAction actionWithTitle:title style:style handler:^(UIAlertAction *action) {


### PR DESCRIPTION
Fixes issue with Xcode autocompletion which currently leaves out the empty parameter name which leads to compilation errors.
