### PR TITLE
Moving call for KVO changes into `@synchronized` on `OPOperation` `-setState:`

### DIFF
--- a/Pod/Classes/Operations/OPOperation.m
+++ b/Pod/Classes/Operations/OPOperation.m
@@ -131,20 +131,22 @@ typedef NS_ENUM(NSUInteger, OPOperationState) {
     }
 }
 
++ (BOOL)automaticallyNotifiesObserversOfState
+{
+    return NO;
+}
+
 - (void)setState:(OPOperationState)newState
 {
-    [self willChangeValueForKey:NSStringFromSelector(@selector(state))];
-    
     @synchronized(self) {
         // Guard against calling if state is currently finished
         if (_state != OPOperationStateFinished) {
             NSAssert(_state != newState, @"Performing invalid cyclic state transition.");
-            
+            [self willChangeValueForKey:@"state"];
             _state = newState;
+            [self didChangeValueForKey:@"state"];
         }
     }
-
-    [self didChangeValueForKey:NSStringFromSelector(@selector(state))];
 }
 
 - (void)evaluateConditions


### PR DESCRIPTION
- Turning off automatic notification of changes for `state` on
  `OPOperation`
- Moves KVO change notification methods within the `@syncronized` block
  / within the guarding if check for state not equal to finished.

This resolves some issues around thread safety in regards to state
changes as well as KVO notifications on state change being called when
it shouldn’t be.
