### PR TITLE
Adds media permission operation and audio/video conditions

### DIFF
--- a/Pod/Classes/Conditions/OPAudioCondition.h
+++ b/Pod/Classes/Conditions/OPAudioCondition.h
@@ -1,4 +1,4 @@
-// Operative.h
+// OPAudioCondition.h
 // Copyright (c) 2015 Tom Wilson <tom@toms-stuff.net>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,39 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef Pods_Operative_h
-#define Pods_Operative_h
+#import "OPOperationCondition.h"
 
-// Core
-#import "OPOperation.h"
-#import "OPOperationQueue.h"
-#import "OPOperationObserver.h"
+/**
+ *  A condition for verifying microphone permission using AVMediaTypeAudio
+ */
+@interface OPAudioCondition : NSObject <OPOperationCondition>
 
-// Operations
-#import "OPBlockOperation.h"
-#import "OPAlertOperation.h"
-#import "OPURLSessionTaskOperation.h"
-#import "OPGroupOperation.h"
-#import "OPLocationOperation.h"
-#import "OPDelayOperation.h"
-#import "OPMediaPermissionOperation.h"
-
-// Conditions
-#import "OPLocationCondition.h"
-#import "OPOperationConditionMutuallyExclusive.h"
-#import "OPOperationConditionUserNotification.h"
-#import "OPPhotosCondition.h"
-#import "OPReachabilityCondition.h"
-#import "OPRemoteNotificationCondition.h"
-#import "OPSilentCondition.h"
-#import "OPNoCancelledDependenciesCondition.h"
-#import "OPVideoCondition.h"
-#import "OPAudioCondition.h"
-
-// Observers
-#import "OPBlockObserver.h"
-#import "OPBackgroundObserver.h"
-#import "OPNetworkObserver.h"
-#import "OPTimeoutObserver.h"
-
-#endif
+@end

--- a/Pod/Classes/Conditions/OPAudioCondition.m
+++ b/Pod/Classes/Conditions/OPAudioCondition.m
@@ -1,0 +1,63 @@
+// OPAudioCondition.m
+// Copyright (c) 2015 Tom Wilson <tom@toms-stuff.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@import AVFoundation;
+
+#import "OPAudioCondition.h"
+#import "OPMediaPermissionOperation.h"
+
+#import "NSError+Operative.h"
+
+@implementation OPAudioCondition
+
+#pragma mark - OPOperationCondition Protocol
+#pragma mark -
+
+- (NSString *)name
+{
+    return @"Audio";
+}
+
+- (BOOL)isMutuallyExclusive
+{
+    return NO;
+}
+
+- (NSOperation *)dependencyForOperation:(OPOperation *)operation
+{
+    return [[OPMediaPermissionOperation alloc] initWithMediaType:AVMediaTypeAudio];
+}
+
+- (void)evaluateConditionForOperation:(OPOperation *)operation completion:(void (^)(OPOperationConditionResultStatus, NSError *))completion
+{
+    NSArray *availableDevices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeAudio];
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+    
+    if (status == AVAuthorizationStatusAuthorized || [availableDevices count] == 0) {
+        completion(OPOperationConditionResultStatusSatisfied, nil);
+    } else {
+        NSDictionary *userInfo = @{ kOPOperationConditionKey : [self name] };
+        NSError *error = [NSError errorWithCode:OPOperationErrorCodeConditionFailed userInfo:userInfo];
+        completion(OPOperationConditionResultStatusFailed, error);
+    }
+}
+
+@end

--- a/Pod/Classes/Conditions/OPLocationCondition.m
+++ b/Pod/Classes/Conditions/OPLocationCondition.m
@@ -153,9 +153,7 @@ NSString *const kOPAuthorizationStatusKey = @"CLAuthorizationStatus";
 
     // This is an operation that potentially presents an alert so it should
     // be mutually exclusive with anything else that presents an alert.
-    OPOperationConditionMutuallyExclusive *condition;
-    Class cls = [UIAlertController class];
-    condition = [[OPOperationConditionMutuallyExclusive alloc] initWithClass:cls];
+    OPOperationConditionMutuallyExclusive *condition = [OPOperationConditionMutuallyExclusive alertPresentationExclusivity];
 
     [self addCondition:condition];
 

--- a/Pod/Classes/Conditions/OPOperationConditionUserNotification.m
+++ b/Pod/Classes/Conditions/OPOperationConditionUserNotification.m
@@ -71,7 +71,7 @@ NSString * const kDesiredSettings = @"DesiredUserNotificationSettings";
     _application = application;
     _behavior = behavior;
 
-    [self addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[UIAlertController class]]];
+    [self addCondition:[OPOperationConditionMutuallyExclusive alertPresentationExclusivity]];
 
     return self;
 }

--- a/Pod/Classes/Conditions/OPVideoCondition.h
+++ b/Pod/Classes/Conditions/OPVideoCondition.h
@@ -1,4 +1,4 @@
-// Operative.h
+// OPVideoCondition.h
 // Copyright (c) 2015 Tom Wilson <tom@toms-stuff.net>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,39 +19,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef Pods_Operative_h
-#define Pods_Operative_h
 
-// Core
-#import "OPOperation.h"
-#import "OPOperationQueue.h"
-#import "OPOperationObserver.h"
+#import "OPOperationCondition.h"
 
-// Operations
-#import "OPBlockOperation.h"
-#import "OPAlertOperation.h"
-#import "OPURLSessionTaskOperation.h"
-#import "OPGroupOperation.h"
-#import "OPLocationOperation.h"
-#import "OPDelayOperation.h"
-#import "OPMediaPermissionOperation.h"
+/**
+ *  A condition for verifying camera permission using AVMediaTypeVideo.
+ */
+@interface OPVideoCondition : NSObject <OPOperationCondition>
 
-// Conditions
-#import "OPLocationCondition.h"
-#import "OPOperationConditionMutuallyExclusive.h"
-#import "OPOperationConditionUserNotification.h"
-#import "OPPhotosCondition.h"
-#import "OPReachabilityCondition.h"
-#import "OPRemoteNotificationCondition.h"
-#import "OPSilentCondition.h"
-#import "OPNoCancelledDependenciesCondition.h"
-#import "OPVideoCondition.h"
-#import "OPAudioCondition.h"
-
-// Observers
-#import "OPBlockObserver.h"
-#import "OPBackgroundObserver.h"
-#import "OPNetworkObserver.h"
-#import "OPTimeoutObserver.h"
-
-#endif
+@end

--- a/Pod/Classes/Conditions/OPVideoCondition.m
+++ b/Pod/Classes/Conditions/OPVideoCondition.m
@@ -1,0 +1,63 @@
+// OPVideoCondition.m
+// Copyright (c) 2015 Tom Wilson <tom@toms-stuff.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@import AVFoundation;
+
+#import "OPVideoCondition.h"
+#import "OPMediaPermissionOperation.h"
+
+#import "NSError+Operative.h"
+
+@implementation OPVideoCondition
+
+#pragma mark - OPOperationCondition Protocol
+#pragma mark -
+
+- (NSString *)name
+{
+    return @"Video";
+}
+
+- (BOOL)isMutuallyExclusive
+{
+    return NO;
+}
+
+- (NSOperation *)dependencyForOperation:(OPOperation *)operation
+{
+    return [[OPMediaPermissionOperation alloc] initWithMediaType:AVMediaTypeVideo];
+}
+
+- (void)evaluateConditionForOperation:(OPOperation *)operation completion:(void (^)(OPOperationConditionResultStatus, NSError *))completion
+{
+    NSArray *availableDevices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+    
+    if (status == AVAuthorizationStatusAuthorized || [availableDevices count] == 0) {
+        completion(OPOperationConditionResultStatusSatisfied, nil);
+    } else {
+        NSDictionary *userInfo = @{ kOPOperationConditionKey : [self name] };
+        NSError *error = [NSError errorWithCode:OPOperationErrorCodeConditionFailed userInfo:userInfo];
+        completion(OPOperationConditionResultStatusFailed, error);
+    }
+}
+
+@end

--- a/Pod/Classes/Operations/Misc/OPMediaPermissionOperation.h
+++ b/Pod/Classes/Operations/Misc/OPMediaPermissionOperation.h
@@ -1,4 +1,4 @@
-// Operative.h
+// OPMediaPermissionOperation.h
 // Copyright (c) 2015 Tom Wilson <tom@toms-stuff.net>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,39 +19,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef Pods_Operative_h
-#define Pods_Operative_h
-
-// Core
 #import "OPOperation.h"
-#import "OPOperationQueue.h"
-#import "OPOperationObserver.h"
 
-// Operations
-#import "OPBlockOperation.h"
-#import "OPAlertOperation.h"
-#import "OPURLSessionTaskOperation.h"
-#import "OPGroupOperation.h"
-#import "OPLocationOperation.h"
-#import "OPDelayOperation.h"
-#import "OPMediaPermissionOperation.h"
+/**
+ *  `OPMediaPermissionOperation` is an `OPOperation` subclass to request
+ *  permission to use the device's video or audio media type.
+ *
+ - returns: An instance of `OPMediaPermissionOperation`
+ */
+@interface OPMediaPermissionOperation : OPOperation
 
-// Conditions
-#import "OPLocationCondition.h"
-#import "OPOperationConditionMutuallyExclusive.h"
-#import "OPOperationConditionUserNotification.h"
-#import "OPPhotosCondition.h"
-#import "OPReachabilityCondition.h"
-#import "OPRemoteNotificationCondition.h"
-#import "OPSilentCondition.h"
-#import "OPNoCancelledDependenciesCondition.h"
-#import "OPVideoCondition.h"
-#import "OPAudioCondition.h"
+- (instancetype)initWithMediaType:(NSString *)mediaType NS_DESIGNATED_INITIALIZER;
 
-// Observers
-#import "OPBlockObserver.h"
-#import "OPBackgroundObserver.h"
-#import "OPNetworkObserver.h"
-#import "OPTimeoutObserver.h"
+- (instancetype)init NS_UNAVAILABLE;
 
-#endif
+@end


### PR DESCRIPTION
Similar to OPLocationCondition and OPRemoteNotificationCondition, this PR implements a media permission operation for prompting the user to enable video or audio permissions.

I also updated location and notification conditions to use `alertPresentationExclusivity`.
