### PR TITLE
Add debugging capabilities to Operative

### DIFF
--- a/Pod/Classes/Core/Operation Queue/OPOperationQueue.m
+++ b/Pod/Classes/Core/Operation Queue/OPOperationQueue.m
@@ -28,6 +28,34 @@
 
 @implementation OPOperationQueue
 
+#pragma mark - Debugging
+#pragma mark -
+
+- (NSString *)debugDescription
+{
+    NSMutableString *mutableString = [[NSMutableString alloc] init];
+    NSArray *operations = [[self operations] copy];
+    
+    NSString *description = [super debugDescription];
+    NSString *state = [self isSuspended] ? @"YES" : @"NO";
+    
+    NSString *result;
+    
+    for(NSOperation *op in operations)
+    {
+        NSArray *lines = [[op debugDescription] componentsSeparatedByString:@"\n"];
+        
+        for(NSString *str in lines)
+        {
+            [mutableString appendFormat:@"\t%@\n", str];
+        }
+    }
+    
+    result = [NSString stringWithFormat:@"%@ { isSuspended = %@ }\n%@", description, state, mutableString];
+    
+    return [result stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+}
+
 - (void)addOperation:(NSOperation *)operation
 {
     if ([operation isKindOfClass:[OPOperation class]]) {

--- a/Pod/Classes/Core/Operations/Misc/OPGroupOperation.m
+++ b/Pod/Classes/Core/Operations/Misc/OPGroupOperation.m
@@ -42,6 +42,26 @@
 
 @implementation OPGroupOperation
 
+#pragma mark - Debugging
+#pragma mark -
+
+- (NSString *)debugDescription
+{
+    NSMutableString *mutableString = [[NSMutableString alloc] init];
+    NSString *description = [super debugDescription];
+    NSString *result;
+    
+    NSArray *lines = [[self.internalQueue debugDescription] componentsSeparatedByString:@"\n"];
+    
+    for(NSString *str in lines)
+    {
+        [mutableString appendFormat:@"\t%@\n", str];
+    }
+    
+    result = [description stringByAppendingFormat:@"\n%@", mutableString];
+    
+    return [result stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+}
 
 #pragma mark -
 #pragma mark -

--- a/Pod/Classes/Core/Operations/OPOperation.m
+++ b/Pod/Classes/Core/Operations/OPOperation.m
@@ -95,6 +95,47 @@ typedef NS_ENUM(NSUInteger, OPOperationState) {
 @implementation OPOperation
 @synthesize state = _state;
 
+#pragma mark - Debugging
+#pragma mark -
+
+- (NSString *)debugDescription
+{
+    NSString *description = [super debugDescription];
+    NSString *state;
+    
+    switch (self.state)
+    {
+        case OPOperationStateReady:
+            state = @"Ready";
+            break;
+            
+        case OPOperationStatePending:
+            state = @"Pending";
+            break;
+            
+        case OPOperationStateFinished:
+            state = @"Finished";
+            break;
+            
+        case OPOperationStateExecuting:
+            state = @"Executing";
+            break;
+            
+        case OPOperationStateFinishing:
+            state = @"Finishing";
+            break;
+            
+        case OPOperationStateInitialized:
+            state = @"Initialized";
+            break;
+            
+        case OPOperationStateEvaluatingConditions:
+            state = @"EvaluatingConditions";
+            break;
+    }
+    
+    return [NSString stringWithFormat:@"%@ (%@)", description, state];
+}
 
 #pragma mark - KVO
 #pragma mark -


### PR DESCRIPTION
This PR adds ability to print out the entire operation tree. It works for all of three fundamental classes such as `OPOperationQueue`, `OPOperation` and `OPGroupOperation`.

Example output:

```
<MaintenanceOperation: 0x7fbc22371ec0> (Pending)
    <OPOperationQueue: 0x7fbc22371b30>{name = 'NSOperationQueue 0x7fbc22371b30'} { isSuspended = YES }
        <ExpenseNotificationCancelOperation: 0x7fbc22372bb0> (Ready)
        <CoreDataStackReadyWaitOperation: 0x7fbc220aa400> (Ready)
        <PersistentStoreChangeConditionOperation: 0x7fbc220e51b0> (Ready)
        <RepeatExpensesOperation: 0x7fbc223734d0> (Pending)
        <CoreDataStackReadyWaitOperation: 0x7fbc220e5700> (Ready)
        <PersistentStoreChangeConditionOperation: 0x7fbc220e5aa0> (Ready)
        <ExpenseExchangeRatesMaintenanceOperation: 0x7fbc22372e10> (Pending)
        <SubmissionMaintenanceOperation: 0x7fbc22373950> (Ready)
            <OPOperationQueue: 0x7fbc223742a0>{name = 'NSOperationQueue 0x7fbc223742a0'} { isSuspended = YES }
                <CoreDataStackReadyWaitOperation: 0x7fbc22374800> (Ready)
                <PersistentStoreChangeConditionOperation: 0x7fbc22374a60> (Ready)
                <TrackSubmissionsOperation: 0x7fbc223739b0> (Pending)
                <CoreDataStackReadyWaitOperation: 0x7fbc22375200> (Ready)
                <PersistentStoreChangeConditionOperation: 0x7fbc22375470> (Ready)
                <SendSubmissionNotificationsOperation: 0x7fbc22373c90> (Pending)
```
