### PR TITLE
Add conditions evaluation operation.

### DIFF
--- a/Example/Operative.xcodeproj/project.pbxproj
+++ b/Example/Operative.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		36BA00E658229C477F35A1DB /* libPods-Operative_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 860340B98354D8E2F499AE43 /* libPods-Operative_Example.a */; };
 		580043761CBEBA4B002AAA36 /* StressTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 580043751CBEBA4B002AAA36 /* StressTests.m */; };
 		58898F091BEE0975001AC718 /* BlockObserversTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58898F081BEE0975001AC718 /* BlockObserversTests.m */; };
+		58FC2F991CBF9A0300F4A169 /* EvaluationOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58FC2F981CBF9A0300F4A169 /* EvaluationOperationTests.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -45,6 +46,7 @@
 		3050B054C14E8A45839ECF46 /* Pods-Operative_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Tests/Pods-Operative_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		580043751CBEBA4B002AAA36 /* StressTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StressTests.m; sourceTree = "<group>"; };
 		58898F081BEE0975001AC718 /* BlockObserversTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlockObserversTests.m; sourceTree = "<group>"; };
+		58FC2F981CBF9A0300F4A169 /* EvaluationOperationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EvaluationOperationTests.m; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* Operative_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Operative_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -169,6 +171,7 @@
 				6003F5BB195388D20070C39A /* Tests.m */,
 				E220B58E1B36BE8E00D706E1 /* CategoriesTests.m */,
 				58898F081BEE0975001AC718 /* BlockObserversTests.m */,
+				58FC2F981CBF9A0300F4A169 /* EvaluationOperationTests.m */,
 				580043751CBEBA4B002AAA36 /* StressTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
@@ -410,6 +413,7 @@
 			files = (
 				6003F5BC195388D20070C39A /* Tests.m in Sources */,
 				58898F091BEE0975001AC718 /* BlockObserversTests.m in Sources */,
+				58FC2F991CBF9A0300F4A169 /* EvaluationOperationTests.m in Sources */,
 				E220B5901B36BE9100D706E1 /* CategoriesTests.m in Sources */,
 				580043761CBEBA4B002AAA36 /* StressTests.m in Sources */,
 			);

--- a/Example/Operative.xcodeproj/project.pbxproj
+++ b/Example/Operative.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		384FDD4BFEF0CB0D7C337ED9 /* libPods-Operative_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DD333458C06BA20BE462E473 /* libPods-Operative_Tests.a */; };
+		36BA00E658229C477F35A1DB /* libPods-Operative_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 860340B98354D8E2F499AE43 /* libPods-Operative_Example.a */; };
+		580043761CBEBA4B002AAA36 /* StressTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 580043751CBEBA4B002AAA36 /* StressTests.m */; };
 		58898F091BEE0975001AC718 /* BlockObserversTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58898F081BEE0975001AC718 /* BlockObserversTests.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
@@ -22,7 +23,7 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		6003F5BC195388D20070C39A /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5BB195388D20070C39A /* Tests.m */; };
-		70EA98EA07D902F682087222 /* libPods-Operative_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C7ABEF2BD4F68B1C56823B87 /* libPods-Operative_Example.a */; };
+		845CD7377065AB3EBB316C04 /* libPods-Operative_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CBA8D3AD33ADD11F9E3934FD /* libPods-Operative_Tests.a */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		E220B57D1B35730800D706E1 /* GroupOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E220B57C1B35730800D706E1 /* GroupOperationTest.m */; };
 		E220B5901B36BE9100D706E1 /* CategoriesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E220B58E1B36BE8E00D706E1 /* CategoriesTests.m */; };
@@ -41,6 +42,8 @@
 /* Begin PBXFileReference section */
 		0A8F82578DDF2C89BEDA7C41 /* Operative.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Operative.podspec; path = ../Operative.podspec; sourceTree = "<group>"; };
 		2DE792D5C4560BBB37DB3592 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		3050B054C14E8A45839ECF46 /* Pods-Operative_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Tests/Pods-Operative_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		580043751CBEBA4B002AAA36 /* StressTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StressTests.m; sourceTree = "<group>"; };
 		58898F081BEE0975001AC718 /* BlockObserversTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlockObserversTests.m; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* Operative_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Operative_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -60,17 +63,16 @@
 		6003F5B7195388D20070C39A /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		6003F5BB195388D20070C39A /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
-		6496CE77A28F4CF9403FE205 /* Pods-Operative_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Tests/Pods-Operative_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		860340B98354D8E2F499AE43 /* libPods-Operative_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Operative_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		904FB393F6D2C9F1CB51660B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		9CCCE505F8F1D317FB7A0F1A /* Pods-Operative_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Example/Pods-Operative_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		A070180E290F7E7E95C81EDF /* Pods-Operative_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Tests/Pods-Operative_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		C7ABEF2BD4F68B1C56823B87 /* libPods-Operative_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Operative_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		DC10B5FA8CD884288039F11E /* Pods-Operative_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Example/Pods-Operative_Example.release.xcconfig"; sourceTree = "<group>"; };
-		DD333458C06BA20BE462E473 /* libPods-Operative_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Operative_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F2E06E562398CD873308840 /* Pods-Operative_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Tests/Pods-Operative_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		CBA8D3AD33ADD11F9E3934FD /* libPods-Operative_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Operative_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E220B57B1B35730800D706E1 /* GroupOperationTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GroupOperationTest.h; sourceTree = "<group>"; };
 		E220B57C1B35730800D706E1 /* GroupOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GroupOperationTest.m; sourceTree = "<group>"; };
 		E220B58E1B36BE8E00D706E1 /* CategoriesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CategoriesTests.m; sourceTree = "<group>"; };
+		E232E014FBDD619DA5A3494C /* Pods-Operative_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Example/Pods-Operative_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		FE42C8B54A9AD40C8F14C2CD /* Pods-Operative_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Operative_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Operative_Example/Pods-Operative_Example.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,7 +83,7 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				70EA98EA07D902F682087222 /* libPods-Operative_Example.a in Frameworks */,
+				36BA00E658229C477F35A1DB /* libPods-Operative_Example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,7 +94,7 @@
 				6003F5B0195388D20070C39A /* XCTest.framework in Frameworks */,
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
-				384FDD4BFEF0CB0D7C337ED9 /* libPods-Operative_Tests.a in Frameworks */,
+				845CD7377065AB3EBB316C04 /* libPods-Operative_Tests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,7 +109,7 @@
 				6003F5B5195388D20070C39A /* Tests */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
-				756BC41DFD5584AF84EAB546 /* Pods */,
+				B4DE278C6C79949DDD5748F3 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -127,8 +129,8 @@
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
-				C7ABEF2BD4F68B1C56823B87 /* libPods-Operative_Example.a */,
-				DD333458C06BA20BE462E473 /* libPods-Operative_Tests.a */,
+				860340B98354D8E2F499AE43 /* libPods-Operative_Example.a */,
+				CBA8D3AD33ADD11F9E3934FD /* libPods-Operative_Tests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -167,6 +169,7 @@
 				6003F5BB195388D20070C39A /* Tests.m */,
 				E220B58E1B36BE8E00D706E1 /* CategoriesTests.m */,
 				58898F081BEE0975001AC718 /* BlockObserversTests.m */,
+				580043751CBEBA4B002AAA36 /* StressTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -191,13 +194,13 @@
 			name = "Podspec Metadata";
 			sourceTree = "<group>";
 		};
-		756BC41DFD5584AF84EAB546 /* Pods */ = {
+		B4DE278C6C79949DDD5748F3 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				9CCCE505F8F1D317FB7A0F1A /* Pods-Operative_Example.debug.xcconfig */,
-				DC10B5FA8CD884288039F11E /* Pods-Operative_Example.release.xcconfig */,
-				6496CE77A28F4CF9403FE205 /* Pods-Operative_Tests.debug.xcconfig */,
-				A070180E290F7E7E95C81EDF /* Pods-Operative_Tests.release.xcconfig */,
+				E232E014FBDD619DA5A3494C /* Pods-Operative_Example.debug.xcconfig */,
+				FE42C8B54A9AD40C8F14C2CD /* Pods-Operative_Example.release.xcconfig */,
+				9F2E06E562398CD873308840 /* Pods-Operative_Tests.debug.xcconfig */,
+				3050B054C14E8A45839ECF46 /* Pods-Operative_Tests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -209,12 +212,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "Operative_Example" */;
 			buildPhases = (
-				36675761CF7CD0C573D1EEFF /* Check Pods Manifest.lock */,
+				4EE6388748A98344C726813B /* Check Pods Manifest.lock */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				AF30B82F22B6287864B03507 /* Embed Pods Frameworks */,
-				A10FF0B3BBCF694AA1BF0A2E /* Copy Pods Resources */,
+				BD212F0F517F8238E8AE266D /* Embed Pods Frameworks */,
+				FA0B9046E0297BEBD3608494 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -229,12 +232,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "Operative_Tests" */;
 			buildPhases = (
-				D596272964D318C4857C4911 /* Check Pods Manifest.lock */,
+				6043CDAE49285D57D7DC6127 /* Check Pods Manifest.lock */,
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
-				3DFE8D209069BEB69A8D65FF /* Embed Pods Frameworks */,
-				B3AF5DA14C3690574A05B1CB /* Copy Pods Resources */,
+				139F83E782F3B67CB3CE15F1 /* Embed Pods Frameworks */,
+				AEEBD182406C81827BA6E94B /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -297,22 +300,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		36675761CF7CD0C573D1EEFF /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		3DFE8D209069BEB69A8D65FF /* Embed Pods Frameworks */ = {
+		139F83E782F3B67CB3CE15F1 /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -327,37 +315,37 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Operative_Tests/Pods-Operative_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A10FF0B3BBCF694AA1BF0A2E /* Copy Pods Resources */ = {
+		4EE6388748A98344C726813B /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Operative_Example/Pods-Operative_Example-resources.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		AF30B82F22B6287864B03507 /* Embed Pods Frameworks */ = {
+		6043CDAE49285D57D7DC6127 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Operative_Example/Pods-Operative_Example-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		B3AF5DA14C3690574A05B1CB /* Copy Pods Resources */ = {
+		AEEBD182406C81827BA6E94B /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -372,19 +360,34 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Operative_Tests/Pods-Operative_Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D596272964D318C4857C4911 /* Check Pods Manifest.lock */ = {
+		BD212F0F517F8238E8AE266D /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Operative_Example/Pods-Operative_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FA0B9046E0297BEBD3608494 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Operative_Example/Pods-Operative_Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -408,6 +411,7 @@
 				6003F5BC195388D20070C39A /* Tests.m in Sources */,
 				58898F091BEE0975001AC718 /* BlockObserversTests.m in Sources */,
 				E220B5901B36BE9100D706E1 /* CategoriesTests.m in Sources */,
+				580043761CBEBA4B002AAA36 /* StressTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -516,7 +520,7 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9CCCE505F8F1D317FB7A0F1A /* Pods-Operative_Example.debug.xcconfig */;
+			baseConfigurationReference = E232E014FBDD619DA5A3494C /* Pods-Operative_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -533,7 +537,7 @@
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC10B5FA8CD884288039F11E /* Pods-Operative_Example.release.xcconfig */;
+			baseConfigurationReference = FE42C8B54A9AD40C8F14C2CD /* Pods-Operative_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -550,7 +554,7 @@
 		};
 		6003F5C3195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6496CE77A28F4CF9403FE205 /* Pods-Operative_Tests.debug.xcconfig */;
+			baseConfigurationReference = 9F2E06E562398CD873308840 /* Pods-Operative_Tests.debug.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -570,7 +574,7 @@
 		};
 		6003F5C4195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A070180E290F7E7E95C81EDF /* Pods-Operative_Tests.release.xcconfig */;
+			baseConfigurationReference = 3050B054C14E8A45839ECF46 /* Pods-Operative_Tests.release.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",

--- a/Example/Tests/EvaluationOperationTests.m
+++ b/Example/Tests/EvaluationOperationTests.m
@@ -1,0 +1,290 @@
+//
+//  EvaluationOperationTests.m
+//  Operative
+//
+//  Created by pronebird on 4/14/16.
+//  Copyright © 2016 Tom Wilson. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <Operative/Operative.h>
+
+
+//
+// OPEvaluationTestState used to describe operation lifecycle.
+//
+
+typedef NS_ENUM(NSInteger, OPEvaluationTestState) {
+    OPEvaluationTestStateInitialized,
+    
+    OPEvaluationTestStateBeganDependency,
+    OPEvaluationTestStateFinishedDependency,
+    
+    OPEvaluationTestStateBeganEvaluation,
+    OPEvaluationTestStateFinishedEvaluation,
+    
+    OPEvaluationTestStateBeganOperation,
+    OPEvaluationTestStateFinishedOperation
+};
+
+
+//
+// Convert OPEvaluationTestState to NSString
+//
+
+static NSString * NSStringFromOPEvaluationTestState(OPEvaluationTestState state) {
+    switch (state) {
+        case OPEvaluationTestStateInitialized: return @"Initialized";
+        case OPEvaluationTestStateBeganDependency: return @"BeganDependency";
+        case OPEvaluationTestStateFinishedDependency: return @"FinishedDependency";
+        case OPEvaluationTestStateBeganEvaluation: return @"BeganEvaluation";
+        case OPEvaluationTestStateFinishedEvaluation: return @"FinishedEvaluation";
+        case OPEvaluationTestStateBeganOperation: return @"BeganOperation";
+        case OPEvaluationTestStateFinishedOperation: return @"FinishedOperation";
+    }
+}
+
+
+//
+// Test observer used to validate the state transition.
+//
+
+@interface OPEvaluationTestObserver : NSObject
+
+- (instancetype)initWithExpectation:(XCTestExpectation *)expectation failureBlock:(void(^)(NSString *error))failureBlock;
+
+- (void)didChangeState:(OPEvaluationTestState)newState targetOperation:(OPOperation *)operation;
+
+@end
+
+@implementation OPEvaluationTestObserver {
+    XCTestExpectation *_expectation;
+    OPEvaluationTestState _state;
+    void(^_failureBlock)(NSString *error);
+}
+
+- (instancetype)initWithExpectation:(XCTestExpectation *)expectation failureBlock:(void(^)(NSString *error))failureBlock {
+    NSParameterAssert(expectation);
+    
+    self = [super init];
+    if(!self) {
+        return nil;
+    }
+    
+    _expectation = expectation;
+    _state = OPEvaluationTestStateInitialized;
+    _failureBlock = failureBlock;
+    
+    return self;
+}
+
+- (void)didChangeState:(OPEvaluationTestState)newState targetOperation:(OPOperation *)operation {
+    @synchronized (self) {
+        if(![NSThread isMainThread]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self didChangeState:newState targetOperation:operation];
+            });
+            return;
+        }
+        
+        if(newState <= _state) {
+            _failureBlock(@"observeStateChange is called out of order.");
+            return;
+        }
+        
+        NSLog(@"%@: Change state %@", [operation description], NSStringFromOPEvaluationTestState(newState));
+        
+        _state = newState;
+        
+        if(_state == OPEvaluationTestStateFinishedOperation) {
+            [_expectation fulfill];
+        }
+    }
+}
+
+@end
+
+
+//
+// Test condition that notifies test observer as condition evaluation proceeds.
+//
+
+@interface OPEvaluationOperationTestCondition : NSObject<OPOperationCondition>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithTestObserver:(OPEvaluationTestObserver *)testObserver;
+
+@end
+
+@implementation OPEvaluationOperationTestCondition {
+    OPEvaluationTestObserver *_testObserver;
+}
+
+- (instancetype)initWithTestObserver:(OPEvaluationTestObserver *)testObserver
+{
+    NSParameterAssert(testObserver);
+    
+    self = [super init];
+    if(!self) {
+        return nil;
+    }
+    
+    _testObserver = testObserver;
+    
+    return self;
+}
+
+- (BOOL)isMutuallyExclusive {
+    return NO;
+}
+
+- (NSString *)name {
+    return NSStringFromClass([self class]);
+}
+
+- (NSOperation *)dependencyForOperation:(OPOperation *)operation {
+    OPBlockOperation *dependency = [[OPBlockOperation alloc] initWithBlock:^(void (^completion)(void)) {
+        // simulate some work
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            completion();
+        });
+    }];
+    OPEvaluationTestObserver *testObserver = _testObserver;
+    
+    __weak OPOperation *weakOperation = operation;
+    
+    [dependency addObserver:[[OPBlockObserver alloc] initWithStartHandler:^(OPOperation *anOperation) {
+        [testObserver didChangeState:OPEvaluationTestStateBeganDependency targetOperation:weakOperation];
+    } produceHandler:^(OPOperation *operation, NSOperation *newOperation) {
+        
+    } finishHandler:^(OPOperation *anOperation, NSArray *errors) {
+        [testObserver didChangeState:OPEvaluationTestStateFinishedDependency targetOperation:weakOperation];
+    }]];
+    
+    return dependency;
+}
+
+- (void)evaluateConditionForOperation:(OPOperation *)operation
+                           completion:(void (^)(OPOperationConditionResultStatus result, NSError *error))completion
+{
+    [_testObserver didChangeState:OPEvaluationTestStateBeganEvaluation targetOperation:operation];
+    
+    // simulate async evaluation
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+        
+        [_testObserver didChangeState:OPEvaluationTestStateFinishedEvaluation targetOperation:operation];
+        
+        completion(OPOperationConditionResultStatusSatisfied, nil);
+    });
+}
+
+@end
+
+
+//
+// Evaluation Operation Tests
+//
+
+@interface EvaluationOperationTests : XCTestCase
+
+@end
+
+@implementation EvaluationOperationTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testOperationEvaluationOrder
+{
+    OPOperationQueue *queue = [[OPOperationQueue alloc] init];
+
+    for(NSInteger i = 0; i < 5; i++)
+    {
+        OPBlockOperation *targetOperation = [[OPBlockOperation alloc] initWithBlock:^(void (^completion)(void)) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                completion();
+            });
+        }];
+
+        // Create expectation
+        XCTestExpectation *expectation = [self expectationWithDescription:@"Should run a sequence of: condition dependencies, condition evaluation, relevant operation."];
+
+        // Create test observer to follow the state change
+        OPEvaluationTestObserver *testObserver = [[OPEvaluationTestObserver alloc] initWithExpectation:expectation failureBlock:^(NSString *error) {
+            XCTFail(@"%@", error);
+        }];
+        
+        // create test condition notifying state observer
+        OPEvaluationOperationTestCondition *testCondition = [[OPEvaluationOperationTestCondition alloc] initWithTestObserver:testObserver];
+        
+        // notify state observer regarding operation progress
+        [targetOperation addObserver:[[OPBlockObserver alloc] initWithStartHandler:^(OPOperation *operation) {
+            [testObserver didChangeState:OPEvaluationTestStateBeganOperation targetOperation:operation];
+        } produceHandler:^(OPOperation *operation, NSOperation *newOperation) {
+            
+        } finishHandler:^(OPOperation *operation, NSArray *errors) {
+            [testObserver didChangeState:OPEvaluationTestStateFinishedOperation targetOperation:operation];
+        }]];
+        
+        // add condition to target operation
+        [targetOperation addCondition:testCondition];
+        
+        [queue addOperation:targetOperation];
+    }
+    
+    [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testMutuallyExclusiveOperations {
+    OPOperationQueue *queue = [[OPOperationQueue alloc] init];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Expect this to run sequentially."];
+    NSMutableArray *operations = [[NSMutableArray alloc] init];
+    
+    for(NSInteger i = 0; i < 10; i++)
+    {
+        OPBlockOperation *operation = [[OPBlockOperation alloc] initWithBlock:^(void (^completion)(void)) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion();
+            });
+        }];
+        
+        [operation addObserver:[[OPBlockObserver alloc] initWithFinishHandler:^(OPOperation *operation, NSArray *errors) {
+            @synchronized(operations) {
+                [operations removeObject:operation];
+                
+                OPOperation *nextOp = operations.firstObject;
+                
+                if(nextOp)
+                {
+                    //
+                    // Condition evaluation group for mutually exclusive operation should have dependency set to previous target operation
+                    //
+                    XCTAssertFalse(nextOp.isReady, @"Next mutually exclusive operation should not be Ready.");
+                    XCTAssertFalse(nextOp.conditionEvaluationOperation.isReady, @"Next operation's condition should not be Ready.");
+                }
+                else
+                {
+                    [expectation fulfill];
+                }
+            }
+        }]];
+        
+        [operation addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[NSOperation class]]];
+        
+        [operations addObject:operation];
+    }
+    
+    [queue addOperations:operations waitUntilFinished:NO];
+    
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+@end

--- a/Example/Tests/EvaluationOperationTests.m
+++ b/Example/Tests/EvaluationOperationTests.m
@@ -181,6 +181,44 @@ static NSString * NSStringFromOPEvaluationTestState(OPEvaluationTestState state)
 
 @end
 
+//
+// Condition with dependency that produces mutually exclusive operation
+//
+
+@interface OPEvaluationTestOperationProducingCondition : NSObject<OPOperationCondition>
+
+@end
+
+@implementation OPEvaluationTestOperationProducingCondition
+
+- (BOOL)isMutuallyExclusive {
+    return NO;
+}
+
+- (NSString *)name {
+    return NSStringFromClass([self class]);
+}
+
+- (NSOperation *)dependencyForOperation:(OPOperation *)operation {
+    return [[OPBlockOperation alloc] initWithMainQueueBlock:^{
+        OPBlockOperation *exclusiveOp = [[OPBlockOperation alloc] initWithMainQueueBlock:^{
+            NSLog(@"Run produced operation.");
+        }];
+        
+        [exclusiveOp addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[NSOperation class]]];
+        
+        [operation produceOperation:exclusiveOp];
+    }];
+}
+
+- (void)evaluateConditionForOperation:(OPOperation *)operation
+                           completion:(void (^)(OPOperationConditionResultStatus result, NSError *error))completion
+{
+    completion(OPOperationConditionResultStatusSatisfied, nil);
+}
+
+@end
+
 
 //
 // Evaluation Operation Tests
@@ -201,6 +239,15 @@ static NSString * NSStringFromOPEvaluationTestState(OPEvaluationTestState state)
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
 }
+
+//
+// Make sure that operations execute in the right order:
+//
+// 1. Run dependencies
+// 2. Run evaluation
+// 3. Run operation
+//
+//
 
 - (void)testOperationEvaluationOrder
 {
@@ -244,6 +291,10 @@ static NSString * NSStringFromOPEvaluationTestState(OPEvaluationTestState state)
     
     [self waitForExpectationsWithTimeout:30 handler:nil];
 }
+
+//
+// Make sure that mutually exclusive operations run in sequence
+//
 
 - (void)testMutuallyExclusiveOperations {
     OPOperationQueue *queue = [[OPOperationQueue alloc] init];
@@ -290,6 +341,34 @@ static NSString * NSStringFromOPEvaluationTestState(OPEvaluationTestState state)
     [queue addOperations:operations waitUntilFinished:NO];
     
     [self waitForExpectationsWithTimeout:20 handler:nil];
+}
+
+//
+// Make sure that queue does not deadlock if conditions produce mutually exclusive
+// operations with the same categories as relevant operations
+//
+
+- (void)testProduceMutuallyExclusiveOperationFromConditionDependencyShouldNotDeadlock
+{
+    OPOperationQueue *queue = [[OPOperationQueue alloc] init];
+    
+    // queue should be drained
+    [self keyValueObservingExpectationForObject:queue keyPath:@"operationCount" expectedValue:@0];
+    
+    for(NSInteger i = 0; i < 10; i++) {
+        OPBlockOperation *operation = [[OPBlockOperation alloc] initWithMainQueueBlock:^{
+            NSLog(@"Run operation %@", @(i + 1));
+        }];
+        
+        operation.name = [NSString stringWithFormat:@"Operation %@", @(i + 1)];
+        
+        [operation addCondition:[[OPEvaluationTestOperationProducingCondition alloc] init]];
+        [operation addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[NSOperation class]]];
+        
+        [queue addOperation:operation];
+    }
+    
+    [self waitForExpectationsWithTimeout:10 handler:nil];
 }
 
 @end

--- a/Example/Tests/StressTests.m
+++ b/Example/Tests/StressTests.m
@@ -1,0 +1,203 @@
+//
+//  StressTests.m
+//  Operative
+//
+//  Created by pronebird on 4/13/16.
+//  Copyright © 2016 Tom Wilson. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <Operative/Operative.h>
+
+/**
+ *  This condition exists mainly for the purpose of keeping evaluator busy.
+ */
+@interface OPStressTestHollowCondition : NSObject <OPOperationCondition> @end
+
+@implementation OPStressTestHollowCondition
+
+- (BOOL)isMutuallyExclusive {
+    return NO;
+}
+
+- (NSString *)name {
+    return NSStringFromClass([self class]);
+}
+
+- (NSOperation *)dependencyForOperation:(OPOperation *)operation {
+    return [[OPBlockOperation alloc] initWithMainQueueBlock:^{
+        // whatever.
+    }];
+}
+
+- (void)evaluateConditionForOperation:(OPOperation *)operation
+                           completion:(void (^)(OPOperationConditionResultStatus result, NSError *error))completion
+{
+    completion(OPOperationConditionResultStatusSatisfied, nil);
+}
+
+@end
+
+@interface StressTests : XCTestCase
+
+@end
+
+@implementation StressTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - Stress tests for mutually exclusive operations
+#pragma mark -
+
+- (void)testLotsOfMutuallyExclusiveOperations {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Should finish 500,000 mutually exclusive operations."];
+    OPOperationQueue *queue = [[OPOperationQueue alloc] init];
+    
+    [self cycleMutuallyExclusiveOperations:1 operationQueue:queue expectation:expectation];
+    
+    // time for cofee: give it 10 minutes
+    [self waitForExpectationsWithTimeout:600 handler:nil];
+}
+
+- (void)cycleMutuallyExclusiveOperations:(NSInteger)take
+                          operationQueue:(OPOperationQueue *)queue
+                             expectation:(XCTestExpectation *)expectation
+{
+    NSMutableArray *operations = [[NSMutableArray alloc] init];
+    
+    OPBlockOperation *startOperation = [[OPBlockOperation alloc] initWithMainQueueBlock:^{
+        NSLog(@"*** BEGIN TAKE %@ ***", @(take));
+    }];
+    
+    startOperation.name = @"Start operation";
+    
+    __weak __typeof__(self) weakSelf = self;
+    
+    OPBlockOperation *finishOperation = [[OPBlockOperation alloc] initWithMainQueueBlock:^{
+        NSLog(@"*** END TAKE %@ ***", @(take));
+        
+        if(take < 1000)
+        {
+            [weakSelf cycleMutuallyExclusiveOperations:(take + 1)
+                                        operationQueue:queue
+                                           expectation:expectation];
+        }
+        else
+        {
+            NSLog(@"*** THIS IS IT ***");
+            
+            [expectation fulfill];
+        }
+    }];
+    finishOperation.name = @"Finish operation";
+    
+    for(NSInteger i = 0; i < 500; i++)
+    {
+        OPBlockOperation *op = [[OPBlockOperation alloc] initWithBlock:^(void (^completion)(void)) {
+            // just do something async
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+                completion();
+            });
+        }];
+        
+        op.name = [NSString stringWithFormat:@"Operation %@", @(i + 1)];
+        
+        // run one at a time
+        [op addCondition:[OPOperationConditionMutuallyExclusive mutuallyExclusiveWith:[NSOperation class]]];
+        
+        [op addDependency:startOperation];
+        [finishOperation addDependency:op];
+        
+        [operations addObject:op];
+    }
+    
+    [operations addObject:startOperation];
+    [operations addObject:finishOperation];
+    
+    NSLog(@"** ADD %@ operations **", @(operations.count));
+    
+    [queue addOperations:operations waitUntilFinished:NO];
+}
+
+#pragma mark - Stress tests for lots of async operations
+#pragma mark -
+
+- (void)testLotsOfAsyncOperations {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Should finish 500,000 mutually exclusive operations."];
+    OPOperationQueue *queue = [[OPOperationQueue alloc] init];
+    
+    [self cycleOperationsWithHollowCondition:1 operationQueue:queue expectation:expectation];
+    
+    // time for cofee: give it 10 minutes
+    [self waitForExpectationsWithTimeout:600 handler:nil];
+}
+
+- (void)cycleOperationsWithHollowCondition:(NSInteger)take
+                            operationQueue:(OPOperationQueue *)queue
+                               expectation:(XCTestExpectation *)expectation
+{
+    NSMutableArray *operations = [[NSMutableArray alloc] init];
+    
+    OPBlockOperation *startOperation = [[OPBlockOperation alloc] initWithMainQueueBlock:^{
+        NSLog(@"*** BEGIN TAKE %@ ***", @(take));
+    }];
+    
+    startOperation.name = @"Start operation";
+    
+    __weak __typeof__(self) weakSelf = self;
+    
+    OPBlockOperation *finishOperation = [[OPBlockOperation alloc] initWithMainQueueBlock:^{
+        NSLog(@"*** END TAKE %@ ***", @(take));
+        
+        if(take < 1000)
+        {
+            [weakSelf cycleOperationsWithHollowCondition:(take + 1)
+                                          operationQueue:queue
+                                             expectation:expectation];
+        }
+        else
+        {
+            NSLog(@"*** THIS IS IT ***");
+            
+            [expectation fulfill];
+        }
+    }];
+    finishOperation.name = @"Finish operation";
+    
+    for(NSInteger i = 0; i < 500; i++)
+    {
+        OPBlockOperation *op = [[OPBlockOperation alloc] initWithBlock:^(void (^completion)(void)) {
+            // just do something async
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+                completion();
+            });
+        }];
+        
+        op.name = [NSString stringWithFormat:@"Operation %@", @(i + 1)];
+        
+        // just to keep evaluator doing something
+        [op addCondition:[[OPStressTestHollowCondition alloc] init]];
+        
+        [op addDependency:startOperation];
+        [finishOperation addDependency:op];
+        
+        [operations addObject:op];
+    }
+    
+    [operations addObject:startOperation];
+    [operations addObject:finishOperation];
+    
+    NSLog(@"** ADD %@ operations **", @(operations.count));
+    
+    [queue addOperations:operations waitUntilFinished:NO];
+}
+
+@end

--- a/Example/Tests/StressTests.m
+++ b/Example/Tests/StressTests.m
@@ -63,7 +63,7 @@
     
     [self cycleMutuallyExclusiveOperations:1 operationQueue:queue expectation:expectation];
     
-    // time for cofee: give it 10 minutes
+    // time for coffee: give it 10 minutes
     [self waitForExpectationsWithTimeout:600 handler:nil];
 }
 
@@ -131,12 +131,12 @@
 #pragma mark -
 
 - (void)testLotsOfAsyncOperations {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Should finish 500,000 mutually exclusive operations."];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Should finish 500,000 asynchronous operations."];
     OPOperationQueue *queue = [[OPOperationQueue alloc] init];
     
     [self cycleOperationsWithHollowCondition:1 operationQueue:queue expectation:expectation];
     
-    // time for cofee: give it 10 minutes
+    // time for coffee: give it 10 minutes
     [self waitForExpectationsWithTimeout:600 handler:nil];
 }
 

--- a/Pod/Classes/Core/Operation Queue/OPExclusivityController.h
+++ b/Pod/Classes/Core/Operation Queue/OPExclusivityController.h
@@ -38,8 +38,10 @@
  *
  *  @param operation  OPOperation object which requires exclusivity
  *  @param categories Array of strings describing the name of the category of exclusivity
+ *
+ *  @return previous operations in categories.
  */
-- (void)addOperation:(OPOperation *)operation categories:(NSArray *)categories;
+- (NSSet *)addOperation:(OPOperation *)operation categories:(NSArray *)categories;
 
 /**
  *  Unregisters an operation from being mutually exclusive.

--- a/Pod/Classes/Core/Operation Queue/OPExclusivityController.m
+++ b/Pod/Classes/Core/Operation Queue/OPExclusivityController.m
@@ -69,6 +69,9 @@
     if ([operationsWithThisCategory count]) {
         OPOperation *op = [operationsWithThisCategory lastObject];
         [operation addDependency:op];
+        
+        // condition evaluator should wait for mutually exclusive operation too
+        [operation.conditionEvaluationOperation addDependency:op];
     }
 
     operationsWithThisCategory = [operationsWithThisCategory arrayByAddingObject:operation];

--- a/Pod/Classes/Core/Operation Queue/OPOperationQueue.m
+++ b/Pod/Classes/Core/Operation Queue/OPOperationQueue.m
@@ -102,9 +102,7 @@
                 __strong OPOperation *strongOperation = weakOperation;
                 
                 [OPOperationConditionEvaluator evaluateConditions:[strongOperation conditions] operation:strongOperation completion:^(NSArray *failures) {
-                    if(failures.count) {
-                        [strongOperation finishWithErrors:failures];
-                    }
+                    [strongOperation finishedEvaluationWithErrors:failures];
                     
                     completion();
                 }];

--- a/Pod/Classes/Core/Operation Queue/OPOperationQueue.m
+++ b/Pod/Classes/Core/Operation Queue/OPOperationQueue.m
@@ -75,19 +75,47 @@
                                                                            }];
 
         [opOperation addObserver:observer];
-
-        // Extract any dependencies needed by this operation
-        NSMutableArray *dependencies = [[NSMutableArray alloc] init];
-        for (id <OPOperationCondition>condition in [opOperation conditions]) {
-            NSOperation *dependency = [condition dependencyForOperation:opOperation];
-            if (dependency) {
-                [dependencies addObject:dependency];
+        
+        /*
+         Add conditions evaluation operation.
+         
+         Previously condition evaluation would happen on Operation level.
+         However due to bug discovered in NSOperation we cannot safely manipulate NSOperation.isReady.
+         
+         Therefore we have to wrap condition evalutor into operation and make it dependency for main operation.
+         Evaluation errors are then passed back to main operation before its execution.
+         
+         Relevant discussions:
+         
+         1. https://github.com/danthorpe/Operations/issues/175
+         2. https://github.com/Kabal/Operative/issues/51
+         
+         */
+        NSOperation *conditionEvaluationOperation = [opOperation conditionEvaluationOperation];
+        
+        // condition evaluator will be nil if there are no conditions set for operation
+        if(conditionEvaluationOperation)
+        {
+            // Extract any dependencies needed by this operation
+            NSMutableArray *dependencies = [[NSMutableArray alloc] init];
+            for (id <OPOperationCondition>condition in [opOperation conditions]) {
+                NSOperation *dependency = [condition dependencyForOperation:opOperation];
+                if (dependency) {
+                    [dependencies addObject:dependency];
+                }
             }
-        }
-
-        for (NSOperation *dependency in dependencies) {
-            [opOperation addDependency:dependency];
-            [self addOperation:dependency];
+            
+            // make sure operation waits for evaluator to finish
+            [opOperation addDependency:conditionEvaluationOperation];
+            
+            for (NSOperation *dependency in dependencies) {
+                // evaluator should wait for each condition's dependency
+                [conditionEvaluationOperation addDependency:dependency];
+                
+                [self addOperation:dependency];
+            }
+        
+            [self addOperation:conditionEvaluationOperation];
         }
 
         // With condition dependencies added, we can now see if this needs

--- a/Pod/Classes/Core/Operations/OPOperation.h
+++ b/Pod/Classes/Core/Operations/OPOperation.h
@@ -64,6 +64,11 @@
 
 - (void)addDependency:(NSOperation *)operation;
 
+/**
+ *  Returns condition evaluation operation used by OPOperationQueue.
+ */
+- (NSOperation *)conditionEvaluationOperation;
+
 
 ///---------------------------------
 /// @name Execution and Cancellation

--- a/Pod/Classes/Core/Operations/OPOperation.h
+++ b/Pod/Classes/Core/Operations/OPOperation.h
@@ -53,6 +53,11 @@
  */
 @property (strong, nonatomic, readonly) NSMutableArray *conditions;
 
+/**
+ *  Returns condition evaluation operation used by OPOperationQueue.
+ */
+@property (nonatomic, readonly) OPOperation *conditionEvaluationOperation;
+
 
 ///---------------------------------------------
 /// @name Conditions, Observers and Dependencies
@@ -63,11 +68,6 @@
 - (void)addObserver:(id <OPOperationObserver>)observer;
 
 - (void)addDependency:(NSOperation *)operation;
-
-/**
- *  Returns condition evaluation operation used by OPOperationQueue.
- */
-- (NSOperation *)conditionEvaluationOperation;
 
 
 ///---------------------------------

--- a/Pod/Classes/Core/Operations/OPOperation.h
+++ b/Pod/Classes/Core/Operations/OPOperation.h
@@ -53,11 +53,6 @@
  */
 @property (strong, nonatomic, readonly) NSMutableArray *conditions;
 
-/**
- *  Returns condition evaluation operation used by OPOperationQueue.
- */
-@property (nonatomic, readonly) OPOperation *conditionEvaluationOperation;
-
 
 ///---------------------------------------------
 /// @name Conditions, Observers and Dependencies

--- a/Pod/Classes/Core/Operations/OPOperation.h
+++ b/Pod/Classes/Core/Operations/OPOperation.h
@@ -125,4 +125,10 @@
  */
 - (void)finishedWithErrors:(NSArray *)errors;
 
+/**
+ *  Subclasses should not normally override this.
+ *  This method is called by evaluator when all conditions evaluation finished.
+ */
+- (void)finishedEvaluationWithErrors:(NSArray *)errors;
+
 @end

--- a/Pod/Classes/Core/Operations/OPOperation.m
+++ b/Pod/Classes/Core/Operations/OPOperation.m
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 #import "OPOperation.h"
+#import "OPGroupOperation.h"
 #import "OPBlockOperation.h"
 #import "OPOperationCondition.h"
 #import "OPOperationConditionEvaluator.h"
@@ -58,6 +59,7 @@
 
 @synthesize executing = _executing;
 @synthesize finished = _finished;
+@synthesize conditionEvaluationOperation = _conditionEvaluationOperation;
 
 #pragma mark - Debugging
 #pragma mark -
@@ -147,30 +149,47 @@
     [self.conditions addObject:condition];
 }
 
-- (NSOperation *)conditionEvaluationOperation
+- (OPOperation *)conditionEvaluationOperation
 {
-    NSAssert(!self.isExecuting && !self.isFinished, @"Cannot issue condition evaluation operation for already executing or finished operations.");
-    
-    __weak __typeof__(self) weakSelf = self;
-    
-    if(self.conditions.count == 0) {
-        return nil;
-    }
-    
-    OPBlockOperation *evaluationOperation = [[OPBlockOperation alloc] initWithBlock:^(void (^completion)(void)) {
-        __strong __typeof__(self) strongSelf = weakSelf;
+    @synchronized (self) {
+        NSAssert(!self.isExecuting && !self.isFinished, @"Cannot issue condition evaluation operation for already executing or finished operations.");
         
-        [OPOperationConditionEvaluator evaluateConditions:[strongSelf conditions] operation:strongSelf completion:^(NSArray *failures) {
-            [strongSelf.internalErrors addObjectsFromArray:failures];
+        __weak __typeof__(self) weakSelf = self;
+        
+        if(self.conditions.count == 0) {
+            return nil;
+        }
+        
+        if(!_conditionEvaluationOperation) {
+            OPBlockOperation *evaluationOperation = [[OPBlockOperation alloc] initWithBlock:^(void (^completion)(void)) {
+                __strong __typeof__(self) strongSelf = weakSelf;
+                
+                [OPOperationConditionEvaluator evaluateConditions:[strongSelf conditions] operation:strongSelf completion:^(NSArray *failures) {
+                    [strongSelf.internalErrors addObjectsFromArray:failures];
+                    
+                    completion();
+                }];
+            }];
             
-            completion();
-        }];
-    }];
-    
-    evaluationOperation.qualityOfService = self.qualityOfService;
-    evaluationOperation.name = [NSString stringWithFormat:@"Condition evaluator for %@", [self description]];
-    
-    return evaluationOperation;
+            evaluationOperation.qualityOfService = self.qualityOfService;
+            evaluationOperation.name = [NSString stringWithFormat:@"Condition evaluator for %@", [self description]];
+            
+            // Extract any dependencies needed by this operation
+            NSMutableArray *dependencies = [[NSMutableArray alloc] init];
+            for (id <OPOperationCondition> condition in [self conditions]) {
+                NSOperation *dependency = [condition dependencyForOperation:self];
+                if (dependency) {
+                    [dependencies addObject:dependency];
+                    
+                    [evaluationOperation addDependency:dependency];
+                }
+            }
+            
+            _conditionEvaluationOperation = [[OPGroupOperation alloc] initWithOperations:[dependencies arrayByAddingObject:evaluationOperation]];
+        }
+        
+        return _conditionEvaluationOperation;
+    }
 }
 
 

--- a/Pod/Classes/Core/Operations/OPOperation.m
+++ b/Pod/Classes/Core/Operations/OPOperation.m
@@ -262,6 +262,11 @@
     // No-op
 }
 
+- (void)finishedEvaluationWithErrors:(NSArray *)errors
+{
+    [self.internalErrors addObjectsFromArray:errors ?: @[]];
+}
+
 - (void)waitUntilFinished
 {
     NSAssert(NO, @"I'm pretty sure you don't want to do this.");

--- a/Pod/Classes/Core/Operations/OPOperation.m
+++ b/Pod/Classes/Core/Operations/OPOperation.m
@@ -204,8 +204,8 @@
 - (void)cancel {
     [super cancel];
     
-    if([self isFinished]) {
-        return;
+    if([self isExecuting] && ![self isFinished]) {
+        [self finish];
     }
 }
 


### PR DESCRIPTION
Previously condition evaluation would happen on Operation level.
However due to bug discovered in NSOperation we cannot safely manipulate NSOperation.isReady.

Therefore we have to wrap condition evalutor into operation and make it dependency for main operation.
Evaluation errors are then passed back to main operation before its execution.

Relevant discussions:
1. danthorpe/Operations#175
2. Kabal#51
